### PR TITLE
Add Dockerfile, tests, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,7 @@ jobs:
       run: |
         docker build . --file Dockerfile --tag pythia-python:$GITHUB_SHA --compress
         docker images
+    - name: Run test program
+      run: |
         docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out.txt"
+        wc main01_out.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
       run: |
         docker build . --file Dockerfile --tag pythia-python:$GITHUB_SHA --compress
         docker images
-        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA "python tests/main01.py > main01_out.txt"
+        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Run test program in C++
       run: |
         docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
-        main01_out_cpp.txt
+        wc main01_out_cpp.txt
     - name: Run test program in Python
       run: |
         docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out_py.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       run: |
         docker build . \
           --file Dockerfile \
-          --build-arg PYTHON_VERSION=3.7 \
+          --build-arg BASE_IMAGE=python:3.7-slim \
           --build-arg PYTHIA_VERSION=8301 \
           --tag pythia-python:$GITHUB_SHA \
           --compress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,4 @@ jobs:
       run: |
         docker build . --file Dockerfile --tag pythia-python:$GITHUB_SHA --compress
         docker images
+        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA "python tests/main01.py > main01_out.txt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
     - uses: actions/checkout@master
     - name: Build Docker image
       run: |
-        docker build . --file Dockerfile --tag pythia-python:$GITHUB_SHA --compress
+        docker build . \
+          --file Dockerfile \
+          --build-arg PYTHON_VERSION=3.7 \
+          --build-arg PYTHIA_VERSION=8301 \
+          --tag pythia-python:$GITHUB_SHA \
+          --compress
         docker images
     - name: Run test program
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
           --tag pythia-python:$GITHUB_SHA \
           --compress
         docker images
-    - name: Run test program
+    - name: Run test program in C++
       run: |
-        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out.txt"
-        wc main01_out.txt
+        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+        main01_out_cpp.txt
+    - name: Run test program in Python
+      run: |
+        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out_py.txt"
+        wc main01_out_py.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI/CD
+
+on:
+  push:
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Build Docker image
+      run: |
+        docker build . --file Dockerfile --tag pythia-python:$GITHUB_SHA --compress
+        docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,16 @@ RUN mkdir /code && \
     cp -r /code/pythia${PYTHIA_VERSION}/include/* /usr/local/include/ && \
     cp -r /code/pythia${PYTHIA_VERSION}/share/* /usr/local/share/ && \
     rm -rf /code
+
+FROM base
+# Use C.UTF-8 locale to avoid issues with ASCII encoding
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local/include /usr/local/include
+COPY --from=builder /usr/local/share /usr/local/share
 
 ENTRYPOINT /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -qq -y update && \
         g++ \
         wget \
         make \
+        python3-dev \
         sudo
 RUN python3 -m pip install --upgrade --no-cache-dir pip setuptools wheel
 
@@ -21,5 +22,6 @@ RUN mkdir /code && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure \
       --prefix=/usr/local \
+      --arch=Linux \
       --with-python --with-python-include=$(which python3) && \
     make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.7-slim as base
+
+FROM base as builder
+RUN apt-get -qq -y update && \
+    apt-get -qq -y upgrade && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+        gcc \
+        g++ \
+        wget \
+        make \
+        sudo
+RUN python3 -m pip install --upgrade --no-cache-dir pip setuptools wheel
+
+ENV PYTHIA_VERSION=8301
+
+RUN mkdir /code && \
+    cd /code && \
+    wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
+    tar xvfz pythia${PYTHIA_VERSION}.tgz && \
+    ls -lhtr && \
+    cd pythia${PYTHIA_VERSION} && \
+    ./configure \
+      --prefix=/usr/local \
+      --with-python --with-python-include=$(which python3) && \
+    make

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,8 @@ RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
-    ls -lhtr && \
     cd pythia${PYTHIA_VERSION} && \
-    ./configure \
+    CXX=g++ ./configure \
       --prefix=/usr/local \
       --arch=Linux \
       --with-python --with-python-include=$(which python3) && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ RUN mkdir /code && \
       --with-python-lib=/usr/lib/python3.7 \
       --with-python-include=/usr/include/python3.7 && \
     make
+
+ENTRYPOINT /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/local/include /usr/local/include
 COPY --from=builder /usr/local/share /usr/local/share
 
-ENTRYPOINT /bin/bash
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}-slim as base
+#ARG PYTHON_VERSION=3.7
+#FROM python:${PYTHON_VERSION}-slim as base
+FROM python:3.7-slim as base
 
 FROM base as builder
 RUN apt-get -qq -y update && \
@@ -18,6 +19,8 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
+#ENV PYTHIA_VERSION=8301
+ENV PYTHON_VERSION=3.7
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
+# ARG is replicated to use in scope of builder
+ARG PYTHON_VERSION=3.7
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} && \
     ./configure \
       --prefix=/usr/local \
       --arch=Linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM python:3.7-slim as base
 
 FROM base as builder
 RUN apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
         gcc \
         g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ RUN apt-get -qq -y update && \
         wget \
         make \
         python3-dev \
-        sudo
+        sudo && \
+        apt-get -y autoclean && \
+        apt-get -y autoremove && \
+        rm -rf /var/lib/apt-get/lists/*
+
 RUN python3 -m pip install --upgrade --no-cache-dir pip setuptools wheel
 
 ENV PYTHIA_VERSION=8301

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ENV PYTHIA_VERSION=8301
+ENV PYTHON_VERSION=3.7
 
 RUN mkdir /code && \
     cd /code && \
@@ -29,10 +30,9 @@ RUN mkdir /code && \
       --arch=Linux \
       --cxx=g++ \
       --with-gzip \
-      --with-python \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python3.7 \
-      --with-python-include=/usr/include/python3.7 && \
+      --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
+      --with-python-include=/usr/include/python${PYTHON_VERSION} && \
     make
 
 ENTRYPOINT /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,16 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
-ENV PYTHON_VERSION="python --version | awk '{print substr($2, 1, length($2)-2)}'"
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
+# PYTHON_VERSION needs to be set to be in scope for builder
 RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
+    PYTHON_VERSION="$(python --version | awk '{print substr($2, 1, length($2)-2)}')" \
     ./configure \
       --prefix=/usr/local \
       --arch=Linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir /code && \
       --prefix=/usr/local \
       --arch=Linux \
       --cxx=g++ \
+      --with-gzip \
       --with-python \
       --with-python-bin=/usr/local/bin \
       --with-python-lib=/usr/lib/python3.7 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
-# PYTHON_VERSION is copied from ARG to ENV to use in scope of builder
-ENV PYTHON_VERSION=${PYTHON_VERSION}
+# copied from ARG to use in scope of builder
+ENV _PYTHON_VERSION=${PYTHON_VERSION}
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \
@@ -34,8 +34,8 @@ RUN mkdir /code && \
       --cxx=g++ \
       --with-gzip \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
-      --with-python-include=/usr/include/python${PYTHON_VERSION} && \
+      --with-python-lib=/usr/lib/python${_PYTHON_VERSION} \
+      --with-python-include=/usr/include/python${_PYTHON_VERSION} && \
     make -j4 && \
     cp -r /code/pythia${PYTHIA_VERSION}/bin/* /usr/local/bin/ && \
     cp -r /code/pythia${PYTHIA_VERSION}/lib/* /usr/local/lib/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN apt-get -qq -y update && \
     DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
         gcc \
         g++ \
+        zlibc \
+        zlib1g-dev \
+        libbz2-dev \
         wget \
         make \
         python3-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-#ARG PYTHON_VERSION=3.7
-#FROM python:${PYTHON_VERSION}-slim as base
-FROM python:3.7-slim as base
+ARG PYTHON_VERSION=3.7
+FROM python:${PYTHON_VERSION}-slim as base
 
 FROM base as builder
 RUN apt-get -qq -y update && \
@@ -19,8 +18,6 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
-#ENV PYTHIA_VERSION=8301
-ENV PYTHON_VERSION=3.7
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ RUN mkdir /code && \
     CXX=g++ ./configure \
       --prefix=/usr/local \
       --arch=Linux \
-      --with-python --with-python-include=$(which python3) && \
+      --with-python=$(which python3) \
+      --with-python-include=/usr/include/python3.7 && \
     make

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,18 +63,7 @@ COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/local/include /usr/local/include
 COPY --from=builder /usr/local/share /usr/local/share
 
-# Create user "docker" with sudo powers
-RUN useradd -m docker && \
-    usermod -aG sudo docker && \
-    echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    cp /root/.bashrc /home/docker/ && \
-    mkdir /home/docker/data && \
-    chown -R --from=root docker /home/docker
-
-WORKDIR /home/docker/data
-ENV HOME /home/docker
-ENV USER docker
-USER docker
-ENV PATH /home/docker/.local/bin:$PATH
+WORKDIR /home/data
+ENV HOME /home
 
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,10 @@ RUN mkdir /code && \
       --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
       --with-python-include=/usr/include/python${PYTHON_VERSION} && \
     make -j4 && \
-    cp -r /code/pythia8301/bin/* /usr/local/bin/ && \
-    cp -r /code/pythia8301/lib/* /usr/local/lib/ && \
-    cp -r /code/pythia8301/include/* /usr/local/include/ && \
-    cp -r /code/pythia8301/share/* /usr/local/share/ && \
+    cp -r /code/pythia${PYTHIA_VERSION}/bin/* /usr/local/bin/ && \
+    cp -r /code/pythia${PYTHIA_VERSION}/lib/* /usr/local/lib/ && \
+    cp -r /code/pythia${PYTHIA_VERSION}/include/* /usr/local/include/ && \
+    cp -r /code/pythia${PYTHIA_VERSION}/share/* /usr/local/share/ && \
     rm -rf /code
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,14 @@ RUN mkdir /code && \
     rm -rf /code
 
 FROM base
+RUN apt-get -qq -y update && \
+    apt-get -qq -y install \
+        g++ \
+        make && \
+        apt-get -y autoclean && \
+        apt-get -y autoremove && \
+        rm -rf /var/lib/apt-get/lists/*
+
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,8 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
-# ARG is replicated to use in scope of builder
-ARG PYTHON_VERSION=3.7
-ENV PYTHON_VERSION=3.7
+# PYTHON_VERSION is copied from ARG to ENV to use in scope of builder
+ENV PYTHON_VERSION=${PYTHON_VERSION}
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,22 +20,21 @@ RUN apt-get -qq -y update && \
 ARG PYTHIA_VERSION=8301
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
-# _PYTHON_VERSION needs to be set to be in scope for builder
 RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    _PYTHON_VERSION="$(python --version | awk '{print substr($2, 1, length($2)-2)}')" \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} \
     ./configure \
       --prefix=/usr/local \
       --arch=Linux \
       --cxx=g++ \
       --with-gzip \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python${_PYTHON_VERSION} \
-      --with-python-include=/usr/include/python${_PYTHON_VERSION} && \
+      --with-python-lib=/usr/lib/python${PYTHON_MINOR_VERSION} \
+      --with-python-include=/usr/include/python${PYTHON_MINOR_VERSION} && \
     make -j4 && \
     cp -r /code/pythia${PYTHIA_VERSION}/bin/* /usr/local/bin/ && \
     cp -r /code/pythia${PYTHIA_VERSION}/lib/* /usr/local/lib/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -qq -y update && \
 ENV PYTHIA_VERSION=8301
 ENV PYTHON_VERSION=3.7
 
+# In Python 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
@@ -33,6 +34,10 @@ RUN mkdir /code && \
       --with-python-bin=/usr/local/bin \
       --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
       --with-python-include=/usr/include/python${PYTHON_VERSION} && \
-    make
+    make && \
+    cp -r /code/pythia8301/lib/* /usr/local/lib/ && \
+    cp -r /code/pythia8301/share/* /usr/local/share/
+ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 ENTRYPOINT /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:${PYTHON_VERSION}-slim as base
 
 FROM base as builder
 RUN apt-get -qq -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -qq -y install \
+    apt-get -qq -y install \
         gcc \
         g++ \
         zlibc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,18 @@ COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/local/include /usr/local/include
 COPY --from=builder /usr/local/share /usr/local/share
 
+# Create user "docker" with sudo powers
+RUN useradd -m docker && \
+    usermod -aG sudo docker && \
+    echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+    cp /root/.bashrc /home/docker/ && \
+    mkdir /home/docker/data && \
+    chown -R --from=root docker /home/docker
+
+WORKDIR /home/docker/data
+ENV HOME /home/docker
+ENV USER docker
+USER docker
+ENV PATH /home/docker/.local/bin:$PATH
+
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,12 @@ RUN mkdir /code && \
       --with-python-bin=/usr/local/bin \
       --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
       --with-python-include=/usr/include/python${PYTHON_VERSION} && \
-    make && \
+    make -j4 && \
+    cp -r /code/pythia8301/bin/* /usr/local/bin/ && \
     cp -r /code/pythia8301/lib/* /usr/local/lib/ && \
-    cp -r /code/pythia8301/share/* /usr/local/share/
+    cp -r /code/pythia8301/include/* /usr/local/include/ && \
+    cp -r /code/pythia8301/share/* /usr/local/share/ && \
+    rm -rf /code
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}-slim as base
+ARG BASE_IMAGE=python:3.7-slim
+FROM ${BASE_IMAGE} as base
+
+SHELL [ "/bin/bash", "-c" ]
 
 FROM base as builder
 RUN apt-get -qq -y update && \
@@ -20,6 +22,7 @@ RUN apt-get -qq -y update && \
 ARG PYTHIA_VERSION=8301
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
+# PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,18 +64,7 @@ COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/local/include /usr/local/include
 COPY --from=builder /usr/local/share /usr/local/share
 
-# Create user "docker" with sudo powers
-RUN useradd -m docker && \
-    usermod -aG sudo docker && \
-    echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    cp /root/.bashrc /home/docker/ && \
-    mkdir /home/docker/data && \
-    chown -R --from=root docker /home/docker
-
-WORKDIR /home/docker/data
-ENV HOME /home/docker
-ENV USER docker
-USER docker
-ENV PATH /home/docker/.local/bin:$PATH
+WORKDIR /home/data
+ENV HOME /home
 
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,18 @@ COPY --from=builder /usr/local/lib /usr/local/lib
 COPY --from=builder /usr/local/include /usr/local/include
 COPY --from=builder /usr/local/share /usr/local/share
 
-WORKDIR /home/data
-ENV HOME /home
+# Create user "docker" with sudo powers
+RUN useradd -m docker && \
+    usermod -aG sudo docker && \
+    echo '%sudo ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+    cp /root/.bashrc /home/docker/ && \
+    mkdir /home/docker/data && \
+    chown -R --from=root docker /home/docker
+
+WORKDIR /home/docker/data
+ENV HOME /home/docker
+ENV USER docker
+USER docker
+ENV PATH /home/docker/.local/bin:$PATH
 
 ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -qq -y update && \
 ARG PYTHIA_VERSION=8301
 # ARG is replicated to use in scope of builder
 ARG PYTHON_VERSION=3.7
+ENV PYTHON_VERSION=3.7
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq -y update && \
 
 ARG PYTHIA_VERSION=8301
 
-# In Python 8.301 the --prefix option is broken, so cp is used to install software
+# In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.7-slim as base
+ARG PYTHON_VERSION=3.7
+FROM python:${PYTHON_VERSION}-slim as base
 
 FROM base as builder
 RUN apt-get -qq -y update && \
@@ -16,8 +17,7 @@ RUN apt-get -qq -y update && \
         apt-get -y autoremove && \
         rm -rf /var/lib/apt-get/lists/*
 
-ENV PYTHIA_VERSION=8301
-ENV PYTHON_VERSION=3.7
+ARG PYTHIA_VERSION=8301
 
 # In Python 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get -qq -y update && \
         apt-get -y autoremove && \
         rm -rf /var/lib/apt-get/lists/*
 
-RUN python3 -m pip install --upgrade --no-cache-dir pip setuptools wheel
-
 ENV PYTHIA_VERSION=8301
 
 RUN mkdir /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,22 +20,22 @@ RUN apt-get -qq -y update && \
 ARG PYTHIA_VERSION=8301
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
-# PYTHON_VERSION needs to be set to be in scope for builder
+# _PYTHON_VERSION needs to be set to be in scope for builder
 RUN mkdir /code && \
     cd /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    PYTHON_VERSION="$(python --version | awk '{print substr($2, 1, length($2)-2)}')" \
+    _PYTHON_VERSION="$(python --version | awk '{print substr($2, 1, length($2)-2)}')" \
     ./configure \
       --prefix=/usr/local \
       --arch=Linux \
       --cxx=g++ \
       --with-gzip \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
-      --with-python-include=/usr/include/python${PYTHON_VERSION} && \
+      --with-python-lib=/usr/lib/python${_PYTHON_VERSION} \
+      --with-python-include=/usr/include/python${_PYTHON_VERSION} && \
     make -j4 && \
     cp -r /code/pythia${PYTHIA_VERSION}/bin/* /usr/local/bin/ && \
     cp -r /code/pythia${PYTHIA_VERSION}/lib/* /usr/local/lib/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN apt-get -qq -y update && \
         rm -rf /var/lib/apt-get/lists/*
 
 ARG PYTHIA_VERSION=8301
-# copied from ARG to use in scope of builder
-ENV _PYTHON_VERSION=${PYTHON_VERSION}
+ENV PYTHON_VERSION="python --version | awk '{print substr($2, 1, length($2)-2)}'"
 
 # In PYTHIA 8.301 the --prefix option is broken, so cp is used to install software
 RUN mkdir /code && \
@@ -34,8 +33,8 @@ RUN mkdir /code && \
       --cxx=g++ \
       --with-gzip \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python${_PYTHON_VERSION} \
-      --with-python-include=/usr/include/python${_PYTHON_VERSION} && \
+      --with-python-lib=/usr/lib/python${PYTHON_VERSION} \
+      --with-python-include=/usr/include/python${PYTHON_VERSION} && \
     make -j4 && \
     cp -r /code/pythia${PYTHIA_VERSION}/bin/* /usr/local/bin/ && \
     cp -r /code/pythia${PYTHIA_VERSION}/lib/* /usr/local/lib/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir /code && \
     wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
+    ./configure --help && \
     CXX=g++ ./configure \
       --prefix=/usr/local \
       --arch=Linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,12 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    CXX=g++ ./configure \
+    ./configure \
       --prefix=/usr/local \
       --arch=Linux \
-      --with-python=$(which python3) \
+      --cxx=g++ \
+      --with-python \
+      --with-python-bin=/usr/local/bin \
+      --with-python-lib=/usr/lib/python3.7 \
       --with-python-include=/usr/include/python3.7 && \
     make

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--cache-from matthewfeickert/pythia-python:latest \
 	--build-arg BASE_IMAGE=python:3.7-slim \
 	--build-arg PYTHIA_VERSION=8301 \
 	--tag matthewfeickert/pythia-python:pythia8.3-python3.7 \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ image:
 	docker build . \
 	-f Dockerfile \
 	--cache-from matthewfeickert/pythia-python:latest \
-	--build-arg PYTHON_VERSION=3.7 \
+	--build-arg BASE_IMAGE=python:3.7-slim \
 	--build-arg PYTHIA_VERSION=8301 \
 	--tag matthewfeickert/pythia-python:pythia8.3-python3.7 \
 	--tag matthewfeickert/pythia-python:pythia8.301-python3.7 \

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,12 @@ test:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		-c "python tests/main01.py > main01_out.txt"
+		-c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+	wc main01_out_cpp.txt
+	docker run \
+		--rm \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		matthewfeickert/pythia-python:latest \
+		-c "python tests/main01.py > main01_out_py.txt"
+	wc main01_out_py.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+default: image
+
+all: image
+
+image:
+	docker build . \
+	-f Dockerfile \
+	--cache-from matthewfeickert/pythia-python:latest \
+	--tag matthewfeickert/pythia-python:pythia8.3-python3.7 \
+	--tag matthewfeickert/pythia-python:pythia8.301-python3.7 \
+	--tag matthewfeickert/pythia-python:latest
+
+run:
+	docker run --rm -it matthewfeickert/pythia-python:latest

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,11 @@ image:
 
 run:
 	docker run --rm -it matthewfeickert/pythia-python:latest
+
+test:
+	docker run \
+		--rm \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		matthewfeickert/pythia-python:latest \
+		-c "python tests/main01.py > main01_out.txt"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ image:
 	docker build . \
 	-f Dockerfile \
 	--cache-from matthewfeickert/pythia-python:latest \
+	--build-arg PYTHON_VERSION=3.7 \
+	--build-arg PYTHIA_VERSION=8301 \
 	--tag matthewfeickert/pythia-python:pythia8.3-python3.7 \
 	--tag matthewfeickert/pythia-python:pythia8.301-python3.7 \
 	--tag matthewfeickert/pythia-python:latest

--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 > PYTHIA is a program for the generation of high-energy physics events, i.e. for the description of collisions at high energies between elementary particles such as e+, e-, p and pbar in various combinations.
 
 `PYTHIA` 8's source is [distributed on GitLab](https://gitlab.com/Pythia8/releases) and is a product of the [`PYTHIA` development team](http://home.thep.lu.se/~torbjorn/Pythia.html).
+
+## Installation
+
+- Check the [list of available tags on Docker Hub](https://hub.docker.com/r/matthewfeickert/pythia-python/tags?page=1) to find the tag you want.
+- Use `docker pull` to pull down the image corresponding to the tag. For example:
+
+```
+docker pull matthewfeickert/pythia-python:pythia8.301-python3.7
+```
+
+## Use
+
+You can either user the image as "PYTHIA as a service", as demoed here with the test script in the repo
+
+```
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:latest -c "python tests/main01.py > main01_out.txt"
+```
+
+or you can run interactively
+
+```
+docker run --rm -it matthewfeickert/pythia-python:latest
+```

--- a/README.md
+++ b/README.md
@@ -15,10 +15,18 @@ docker pull matthewfeickert/pythia-python:pythia8.301-python3.7
 
 ## Use
 
-You can either user the image as "PYTHIA as a service", as demoed here with the test script in the repo
+You can either user the image as "PYTHIA as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:latest -c "python tests/main01.py > main01_out.txt"
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301-python3.7 \
+  -c "python tests/main01.py > main01_out_py.txt"
+```
+
+or the original C++
+
+```
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301-python3.7 \
+  -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
 ```
 
 or you can run interactively

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# Pythia-Python
-Pythia 8 Docker image with Python 3
+# PYTHIA 8 Docker image with Python 3
+
+> PYTHIA is a program for the generation of high-energy physics events, i.e. for the description of collisions at high energies between elementary particles such as e+, e-, p and pbar in various combinations.
+
+`PYTHIA` 8's source is [distributed on GitLab](https://gitlab.com/Pythia8/releases) and is a product of the [`PYTHIA` development team](http://home.thep.lu.se/~torbjorn/Pythia.html).

--- a/tests/main01.cc
+++ b/tests/main01.cc
@@ -1,0 +1,35 @@
+// main01.cc is a part of the PYTHIA event generator.
+// Copyright (C) 2019 Torbjorn Sjostrand.
+// PYTHIA is licenced under the GNU GPL v2 or later, see COPYING for details.
+// Please respect the MCnet Guidelines, see GUIDELINES for details.
+
+// Keywords: basic usage; charged multiplicity;
+
+// This is a simple test program. It fits on one slide in a talk.
+// It studies the charged multiplicity distribution at the LHC.
+
+#include "Pythia8/Pythia.h"
+using namespace Pythia8;
+int main() {
+  // Generator. Process selection. LHC initialization. Histogram.
+  Pythia pythia;
+  pythia.readString("Beams:eCM = 8000.");
+  pythia.readString("HardQCD:all = on");
+  pythia.readString("PhaseSpace:pTHatMin = 20.");
+  pythia.init();
+  Hist mult("charged multiplicity", 100, -0.5, 799.5);
+  // Begin event loop. Generate event. Skip if error. List first one.
+  for (int iEvent = 0; iEvent < 100; ++iEvent) {
+    if (!pythia.next()) continue;
+    // Find number of all final charged particles and fill histogram.
+    int nCharged = 0;
+    for (int i = 0; i < pythia.event.size(); ++i)
+      if (pythia.event[i].isFinal() && pythia.event[i].isCharged())
+        ++nCharged;
+    mult.fill( nCharged );
+  // End of event loop. Statistics. Histogram. Done.
+  }
+  pythia.stat();
+  cout << mult;
+  return 0;
+}

--- a/tests/main01.py
+++ b/tests/main01.py
@@ -1,0 +1,35 @@
+# main01.py is a part of the PYTHIA event generator.
+# Copyright (C) 2019 Torbjorn Sjostrand.
+# PYTHIA is licenced under the GNU GPL v2 or later, see COPYING for details.
+# Please respect the MCnet Guidelines, see GUIDELINES for details.
+
+# Keywords: basic usage; charged multiplicity; python;
+
+# This is a simple test program. It fits on one slide in a talk.  It
+# studies the charged multiplicity distribution at the LHC.
+
+# Modified by Matthew Feickert to be Python3 compliant and location independent
+
+# Import the Pythia module
+import pythia8
+
+pythia = pythia8.Pythia()
+print(pythia.settings.fvec("Charmonium:gg2ccbar(3S1)[3S1(8)]g"))
+pythia.readString("Beams:eCM = 8000.")
+pythia.readString("HardQCD:all = on")
+pythia.readString("PhaseSpace:pTHatMin = 20.")
+pythia.init()
+mult = pythia8.Hist("charged multiplicity", 100, -0.5, 799.5)
+# Begin event loop. Generate event. Skip if error. List first one.
+for iEvent in range(0, 100):
+    if not pythia.next():
+        continue
+    # Find number of all final charged particles and fill histogram.
+    nCharged = 0
+    for prt in pythia.event:
+        if prt.isFinal() and prt.isCharged():
+            nCharged += 1
+    mult.fill(nCharged)
+# End of event loop. Statistics. Histogram. Done.
+pythia.stat()
+print(mult)


### PR DESCRIPTION
Add Dockerfile, tests, CI with GitHub Actions, and update README

As there seems to be an issue with the `--prefix` configure option in PYTHIA `v8.301` manually copy everything where it needs to be.

```
* Add Dockerfile
   - Use Docker build ARGs to make Dockerfile more modular
* Add test program in C++ and Python
* Add CI with GitHub Actions
* Update README with instructions
```