### PR TITLE
Use 'make install' to properly install to user destination 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,10 +39,7 @@ RUN mkdir /code && \
       --with-python-lib=/usr/lib/python${PYTHON_MINOR_VERSION} \
       --with-python-include=/usr/include/python${PYTHON_MINOR_VERSION} && \
     make -j4 && \
-    cp -r /code/pythia${PYTHIA_VERSION}/bin/* /usr/local/bin/ && \
-    cp -r /code/pythia${PYTHIA_VERSION}/lib/* /usr/local/lib/ && \
-    cp -r /code/pythia${PYTHIA_VERSION}/include/* /usr/local/include/ && \
-    cp -r /code/pythia${PYTHIA_VERSION}/share/* /usr/local/share/ && \
+    make install && \
     rm -rf /code
 
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -qq -y update && \
         libbz2-dev \
         wget \
         make \
+        rsync \
         python3-dev \
         sudo && \
         apt-get -y autoclean && \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker pull matthewfeickert/pythia-python:pythia8.301-python3.7
 
 ## Use
 
-You can either user the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
+You can either use the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
 docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301-python3.7 \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker pull matthewfeickert/pythia-python:pythia8.301-python3.7
 
 ## Use
 
-You can either user the image as "PYTHIA as a service", as demoed here with the test script in the repo using the Python bindings
+You can either user the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
 docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301-python3.7 \


### PR DESCRIPTION
Noting that [the installation instructions mention](https://gitlab.com/Pythia8/releases/-/blob/acc96c3e5332843bce7fa4f4af8d4f8deae0bef3/README) that

> --prefix=DIR : absolute path to a directory where the "bin", "lib", "include", and "share" directories will be copied, by a "gmake install" command subsequent to the "gmake" one. Note that the files in the current working directory are kept.

properly use `make install` to distribute the built libraries using `rsync`.

```
* Use 'make install' to distribute the built libraries
* Add rsync to builder
* Fix typos in README
```