### PR TITLE
Add CI to publish to Docker Hub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,10 +2,10 @@ name: Publish Docker Images
 
 on:
   push:
-    # branches:
-    # - master
-    # tags:
-    # - v*
+    branches:
+    - master
+    tags:
+    - v*
 
 jobs:
   build-and-publish:
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@master
-    - name: Publish to Registry
+    - name: Build and Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@2.12
       with:
         name: matthewfeickert/pythia-python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish Docker Images
+
+on:
+  push:
+    # branches:
+    # - master
+    # tags:
+    # - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Docker images to Docker Hub
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@2.12
+      with:
+        name: matthewfeickert/pythia-python
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        buildoptions: "--compress"
+        tags: "latest,pythia8.3-python3.7,pythia8.301-python3.7"


### PR DESCRIPTION
Add CI workflow using [`elgohr/Publish-Docker-Github-Action`](https://github.com/elgohr/Publish-Docker-Github-Action) to publish the built Docker image to Docker Hub with tags.


```
* Add workflow to publish images to Docker Hub on pushes to master
* Tag published image with current version tags
```