### PR TITLE
ci: Update GitHub Actions for testing build and deployment to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: '$GITHUB_SHA'
+        tags: test
         tag_with_sha: true
         tag_with_ref: true
         push: false
@@ -27,9 +27,9 @@ jobs:
       run: docker images
     - name: Run test program in C++
       run: |
-        docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:$GITHUB_SHA -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+        docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:test -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
         wc main01_out_cpp.txt
     - name: Run test program in Python
       run: |
-        docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out_py.txt"
+        docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:test -c "python tests/main01.py > main01_out_py.txt"
         wc main01_out_py.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI/CD
 
 on:
   push:
+  pull_request:
   schedule:
   - cron:  '1 0 * * *'
 
@@ -13,19 +14,21 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build Docker image
-      run: |
-        docker build . \
-          --file Dockerfile \
-          --build-arg BASE_IMAGE=python:3.7-slim \
-          --build-arg PYTHIA_VERSION=8301 \
-          --tag pythia-python:$GITHUB_SHA \
-          --compress
-        docker images
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
+      with:
+        repository: matthewfeickert/pythia-python
+        dockerfile: Dockerfile
+        tag_with_sha: true
+        tag_with_ref: true
+        push: false
+    - name: List Built Images
+      run: docker images
     - name: Run test program in C++
       run: |
-        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+        docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:$GITHUB_SHA -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
         wc main01_out_cpp.txt
     - name: Run test program in Python
       run: |
-        docker run --rm -v $PWD:$PWD -w $PWD pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out_py.txt"
+        docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:$GITHUB_SHA -c "python tests/main01.py > main01_out_py.txt"
         wc main01_out_py.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tag: $GITHUB_SHA
+        tags: $GITHUB_SHA
         tag_with_sha: true
         tag_with_ref: true
         push: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
+        tag: $GITHUB_SHA
         tag_with_sha: true
         tag_with_ref: true
         push: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: $GITHUB_SHA
+        tags: '$GITHUB_SHA'
         tag_with_sha: true
         tag_with_ref: true
         push: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,21 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build and Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      if: "!(startsWith(github.ref, 'refs/tags/'))"
+      uses: docker/build-push-action@v1
       with:
-        name: matthewfeickert/pythia-python
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        buildoptions: "--compress"
-        tags: "latest,pythia8.3-python3.7,pythia8.301-python3.7"
+        repository: matthewfeickert/pythia-python
+        dockerfile: Dockerfile
+        tags: latest,pythia8.3-python3.7,pythia8.301-python3.7
+    - name: Build and Publish to Registry with Release Tag
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: matthewfeickert/pythia-python
+        dockerfile: Dockerfile
+        tags: latest,latest-stable,pythia8.3-python3.7,pythia8.301-python3.7
+        tag_with_ref: true


### PR DESCRIPTION
Use the [official Docker GitHub Action](https://github.com/docker/build-push-action) to test and publish the Docker image to Docker Hub.

Using the `tag_with_ref` option, tag the image with the version release number and `latest-stable` when the push is a tag release.

```
* Update CI to test build and to deploy to Docker Hub using Docker official GitHub Action
```