### PR TITLE
refactor: Use ENTRYPOINT and CMD to improve command line interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt";
+        "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt";
         wc main01_out_cpp.txt
     - name: Run test program in Python
       run: >-
@@ -39,7 +39,7 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        -c "python tests/main01.py > main01_out_py.txt";
+        "python tests/main01.py > main01_out_py.txt";
         wc main01_out_py.txt
     - name: Test FastJet
       run: >-
@@ -47,11 +47,11 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        -c "g++ tests/test_FastJet.cc -o tests/test_FastJet \$(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet"
+        "g++ tests/test_FastJet.cc -o tests/test_FastJet \$(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet"
     - name: Test FastJet Python
       run: >-
         docker run --rm
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        -c "python tests/test_FastJet.py"
+        "python tests/test_FastJet.py"

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,4 +82,5 @@ COPY --from=builder /usr/local/share /usr/local/share
 WORKDIR /home/data
 ENV HOME /home
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash", "-l", "-c"]
+CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ test:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		-c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+		"g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
 	wc main01_out_cpp.txt
 	docker run \
 		--rm \
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		-c "python tests/main01.py > main01_out_py.txt"
+		"python tests/main01.py > main01_out_py.txt"
 	wc main01_out_py.txt

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ You can either use the image as "`PYTHIA` as a service", as demoed here with the
 
 ```
 docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301 \
-  -c "python tests/main01.py > main01_out_py.txt"
+  "python tests/main01.py > main01_out_py.txt"
 ```
 
 or the original C++
 
 ```
 docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301 \
-  -c "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+  "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
 ```
 
 or you can run interactively


### PR DESCRIPTION
Make `ENTRYPOINT`

```docker
ENTRYPOINT ["/bin/bash", "-l", "-c"]
```

to force a clean shell and to allow for commands passed to the container at the command line to not have to add the `-c` flag. To allow for the `-c` flag without errors of missing commands if no command is entered add a `CMD` of

```docker
CMD ["/bin/bash"]
```

which results in dropping into an interactive Bash session (as desired)

```
$ docker run --rm -it matthewfeickert/pythia-python:pythia8.301 
root@fe7a94954239:~/data#
```

while still keeping the desired behavior of having `CMD ["/bin/bash"]` being overridden by user input

```
docker run --rm -it matthewfeickert/pythia-python:pythia8.301 python
Python 3.7.7 (default, Mar 11 2020, 00:35:40) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>
```

and not affecting non-interactive sessions behavior

```
$ docker run --rm matthewfeickert/pythia-python:pythia8.301
$ docker run --rm matthewfeickert/pythia-python:pythia8.301 "echo $USER"
jovyan
$
```

Inspired from [`atlstats` MR 7](https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/7) and [MR 10](https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/10).

```
* Make ENTRYPOINT shell run in login mode (-l) with following commands read from string (-c)
* Use CMD of ["/bin/bash"] for better default behavior for interactive sessions
* Remove -c flag from README and tests
```