### PR TITLE
refactor: Use better COPY practices to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 
+# Install built code under /copy to COPY to final image
+RUN mkdir -p /copy/local
+
 # Install FastJet
 ARG FASTJET_VERSION=3.3.3
 RUN mkdir /code && \
@@ -31,7 +34,7 @@ RUN mkdir /code && \
     export CXX=$(which g++) && \
     export PYTHON=$(which python) && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/copy/local \
       --enable-pyext=yes && \
     make -j$(($(nproc) - 1)) && \
     make check && \
@@ -49,7 +52,7 @@ RUN mkdir /code && \
     ./configure --help && \
     export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/copy/local \
       --arch=Linux \
       --cxx=g++ \
       --with-gzip \
@@ -74,10 +77,10 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-COPY --from=builder /usr/local/bin /usr/local/bin
-COPY --from=builder /usr/local/lib /usr/local/lib
-COPY --from=builder /usr/local/include /usr/local/include
-COPY --from=builder /usr/local/share /usr/local/share
+COPY --from=builder /copy/local/bin /usr/local/bin
+COPY --from=builder /copy/local/lib /usr/local/lib
+COPY --from=builder /copy/local/include /usr/local/include
+COPY --from=builder /copy/local/share /usr/local/share
 
 WORKDIR /home/data
 ENV HOME /home


### PR DESCRIPTION
If during a `COPY` operation an entire directory is specified,

```docker
FROM base
COPY --from=builder /usr/local/bin /usr/local/bin
COPY --from=builder /usr/local/lib /usr/local/lib
COPY --from=builder /usr/local/include /usr/local/include
COPY --from=builder /usr/local/share /usr/local/share
```

if files that already exist in the destination are copied over from the source all the files will be viewed as changes by Docker, creating a large layer even if only a single file is changed.

To fix this, if the files that are eventually wanted in the final image are installed during build in a non-typical install location

```docker
./configure --prefix=/copy/local
```

and then those files are copied into the final install path 

```docker
FROM base
COPY --from=builder /copy/local/bin /usr/local/bin
COPY --from=builder /copy/local/lib /usr/local/lib
COPY --from=builder /copy/local/include /usr/local/include
COPY --from=builder /copy/local/share /usr/local/share
```

the image layer will only include these necessary files and the resulting final image size will be much smaller.

This PR is inspired from [`atlstats` MR 18](https://gitlab.cern.ch/atlas-amglab/atlstats/-/merge_requests/18).

```
* Change install location in builder stage to a non-typical path
* Copy only the necessary installed files to desired final install path
```