### PR TITLE
feat: Update dependencies releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.303,pythia8.303-hepmc2.06.10-fastjet3.3.4-python3.8
+        tags: latest,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.8
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.10-fastjet3.3.4-python3.8
+        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.8
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.7
+        tags: latest,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.8
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.7
+        tags: latest,latest-stable,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.8
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.4-python3.8
+        tags: latest,pythia8.303,pythia8.303-hepmc2.06.10-fastjet3.3.4-python3.8
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.4-python3.8
+        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.10-fastjet3.3.4-python3.8
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.8
+        tags: latest,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.4-python3.8
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.8
+        tags: latest,latest-stable,pythia8.301,pythia8.301-hepmc2.06.10-fastjet3.3.4-python3.8
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,8 @@ RUN mkdir /code && \
       --cxx=g++ \
       --with-gzip \
       --with-python-bin=/usr/local/bin \
-      --with-python-lib=/usr/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/include/python${PYTHON_MINOR_VERSION} && \
+      --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
+      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} && \
     make -j$(($(nproc) - 1)) && \
     make install && \
     rm -rf /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.7-slim
+ARG BASE_IMAGE=python:3.8-slim
 FROM ${BASE_IMAGE} as base
 
 SHELL [ "/bin/bash", "-c" ]
@@ -106,7 +106,7 @@ COPY --from=builder /usr/local/share/HepMC /usr/local/share/HepMC
 # copy FastJet
 COPY --from=builder /usr/local/bin/fastjet-config /usr/local/bin/
 COPY --from=builder /usr/local/lib/libfastjet* /usr/local/lib/
-COPY --from=builder /usr/local/lib/python3.7/site-packages/*fastjet* /usr/local/lib/python3.7/site-packages/
+COPY --from=builder /usr/local/lib/python3.8/site-packages/*fastjet* /usr/local/lib/python3.8/site-packages/
 COPY --from=builder /usr/local/lib/libsiscone* /usr/local/lib/
 COPY --from=builder /usr/local/include/fastjet /usr/local/include/fastjet
 COPY --from=builder /usr/local/include/siscone /usr/local/include/siscone

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install FastJet
-ARG FASTJET_VERSION=3.3.3
+ARG FASTJET_VERSION=3.3.4
 RUN mkdir /code && \
     cd /code && \
     wget http://fastjet.fr/repo/fastjet-${FASTJET_VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ RUN mkdir /code && \
       --arch=Linux \
       --cxx=g++ \
       --with-gzip \
+      --with-hepmc2 \
+      --with-fastjet3 \
       --with-python-bin=/usr/local/bin \
       --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \
       --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8301
+ARG PYTHIA_VERSION=8303
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt-get/lists/*
 
 # Install HepMC
-ARG HEPMC_VERSION=2.06.10
+ARG HEPMC_VERSION=2.06.11
 RUN mkdir /code && \
     cd /code && \
     wget http://hepmc.web.cern.ch/hepmc/releases/hepmc${HEPMC_VERSION}.tgz && \

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ image:
 	--build-arg BASE_IMAGE=python:3.8-slim \
 	--build-arg HEPMC_VERSION=2.06.10 \
 	--build-arg FASTJET_VERSION=3.3.4 \
-	--build-arg PYTHIA_VERSION=8301 \
-	--tag matthewfeickert/pythia-python:pythia8.301 \
-	--tag matthewfeickert/pythia-python:pythia8.301-hepmc2.06.10-fastjet3.3.4-python3.8 \
+	--build-arg PYTHIA_VERSION=8303 \
+	--tag matthewfeickert/pythia-python:pythia8.303 \
+	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.10-fastjet3.3.4-python3.8 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ image:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=python:3.8-slim \
-	--build-arg HEPMC_VERSION=2.06.10 \
+	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg PYTHIA_VERSION=8303 \
 	--tag matthewfeickert/pythia-python:pythia8.303 \
-	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.10-fastjet3.3.4-python3.8 \
+	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.8 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,12 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=python:3.7-slim \
+	--build-arg BASE_IMAGE=python:3.8-slim \
 	--build-arg HEPMC_VERSION=2.06.10 \
 	--build-arg FASTJET_VERSION=3.3.3 \
 	--build-arg PYTHIA_VERSION=8301 \
 	--tag matthewfeickert/pythia-python:pythia8.301 \
-	--tag matthewfeickert/pythia-python:pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.7 \
+	--tag matthewfeickert/pythia-python:pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.8 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ image:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=python:3.8-slim \
 	--build-arg HEPMC_VERSION=2.06.10 \
-	--build-arg FASTJET_VERSION=3.3.3 \
+	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg PYTHIA_VERSION=8301 \
 	--tag matthewfeickert/pythia-python:pythia8.301 \
-	--tag matthewfeickert/pythia-python:pythia8.301-hepmc2.06.10-fastjet3.3.3-python3.8 \
+	--tag matthewfeickert/pythia-python:pythia8.301-hepmc2.06.10-fastjet3.3.4-python3.8 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull matthewfeickert/pythia-python:pythia8.301
+docker pull matthewfeickert/pythia-python:pythia8.303
 ```
 
 ## Use
@@ -21,14 +21,14 @@ docker pull matthewfeickert/pythia-python:pythia8.301
 You can either use the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301 \
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.303 \
   "python tests/main01.py > main01_out_py.txt"
 ```
 
 or the original C++
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.301 \
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.303 \
   "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@
 
 `PYTHIA` 8's source is [distributed on GitLab](https://gitlab.com/Pythia8/releases) and is a product of the [`PYTHIA` development team](http://home.thep.lu.se/~torbjorn/Pythia.html).
 
+## Distributed Software
+
+The Docker image contains:
+
+* Python 3.8
+* [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
+* [FastJet](http://fastjet.fr/) `v3.3.4`
+* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
+
 ## Installation
 
 - Check the [list of available tags on Docker Hub](https://hub.docker.com/r/matthewfeickert/pythia-python/tags?page=1) to find the tag you want.


### PR DESCRIPTION
Update Python to Python 3.8 and update all the installed software to their latest stable releases.

Enables:
```
~/data# pythia8-config 
Usage: ./pythia8-config [OPTIONS]

Configuration tool for the PYTHIA event generator library. The available 
options are defined below. All available options (without arguments) for the 
PYTHIA configuration script are also valid for this script. See 
"./configuration --help" in the top PYTHIA 8 directory for more details. 

Available options.
--help         : Print this help message (also -h, --h, and -help).
--config       : Print the argument(s) used to configure Pythia.
--prefix       : Installation prefix (cf. autoconf). Note that if the 
                 installation is spread over multiple directories, the
                 binary directory with the trailing "bin" removed is
                 then returned.
--bindir       : PYTHIA binary directory (equivalent to --prefix-bin).
--libdir       : PYTHIA library directory (equivalent to --prefix-lib).
--includedir   : PYTHIA header directory (equivalent to --prefix-include).
--datadir      : PYTHIA share directory (equivalent to --prefix-share).
--xmldoc       : PYTHIA xmldoc directory.
--cxxflags     : Returns the PYTHIA -I flag string needed for compilation.
--cflags       : Equivalent to --cxxflags.
--ldflags      : Returns the PYTHIA -L/-l flag string needed for compilation.
--libs         : Equivalent to --ldflags.
--PACKAGE      : Provides the -I/-L/-l flags needed to link with an external
                 PACKAGE from the following list.
--with-PACKAGE : Returns "true" if the package is enabled, otherwise "false".
  evtgen   : Particle decays with the EvtGen decay pacakge, requires HEPMC2.
  fastjet3 : Building of jets using the FastJet package, version 3.
  	     (run fastjet-config --prefix to see which path to use.)
  hepmc2   : Export PYTHIA events to the HEPMC format, version 2.
  hepmc3   : Export PYTHIA events to the HEPMC format, version 3.
  lhapdf5  : Support the use of external PDF sets via LHAPDF, version 5.
  lhapdf6  : Support the use of external PDF sets via LHAPDF, >= version 6.2.
  powheg   : Hard process production with POWHEGBOX matrix element executables.
  rivet    : Support use of RIVET through direct interface.
  root     : Use ROOT trees and histograms with PYTHIA.
             Note: this option automatically invokes DIR/bin/root-config to set 
             the ROOT lib/ and include/ paths. To set your ROOT paths manually
             instead, use --with-root-lib=DIR and --with-root-include=DIR.
  yoda     : Lightweight histogramming package for use with RIVET.
  gzip     : Enable reading of GZIPPED files using the libz library.
  python   : Interface to use PYTHIA in Python.
  mg5mes   : MadGraph matrix element plugins for parton showers.
  openmp   : Multi-threading support via OpenMP.
~/data# pythia8-config --with-fastjet3
true
~/data# pythia8-config --with-hepmc2
true
~/data# pythia8-config --with-python
true
```

Commit summary message:

```
* Update to Python 3.8
* Update to HepMC2 v2.06.11
* Update to FastJet v3.3.4
* Update to PYTHIA v8.303
* Enable HepMC2 and FastJet linking to PYTHIA
```