### PR TITLE
feat: Add LHAPDF support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
         matthewfeickert/pythia-python:test
         "g++ tests/main42.cc -o tests/main42 -lpythia8 -lHepMC -ldl; ./tests/main42 tests/main42.cmnd main42_out.hepmc"
         wc main42_out.hepmc
+    - name: Test LHAPDF CLI
+      run: >-
+        docker run --rm
+        matthewfeickert/pythia-python:test
+        "lhapdf install CT10nlo"
     - name: Test FastJet
       run: >-
         docker run --rm

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,13 +110,6 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 
-# Use C.UTF-8 locale to avoid issues with ASCII encoding
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
-ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-ENV PYTHIA8DATA=/usr/local/share/Pythia8/xmldoc
-
 # copy HepMC
 COPY --from=builder /usr/local/lib/libHepMC* /usr/local/lib/
 COPY --from=builder /usr/local/include/HepMC /usr/local/include/HepMC
@@ -146,6 +139,13 @@ COPY --from=builder /usr/local/share/Pythia8 /usr/local/share/Pythia8
 
 WORKDIR /home/data
 ENV HOME /home
+
+# Use C.UTF-8 locale to avoid issues with ASCII encoding
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV PYTHONPATH=/usr/local/lib:$PYTHONPATH
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+ENV PYTHIA8DATA=/usr/local/share/Pythia8/xmldoc
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ RUN mkdir /code && \
       --cxx=g++ \
       --with-gzip \
       --with-hepmc2 \
+      --with-lhapdf6 \
       --with-fastjet3 \
       --with-python-bin=/usr/local/bin \
       --with-python-lib=/usr/local/lib/python${PYTHON_MINOR_VERSION} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,7 @@ COPY --from=builder /usr/local/share/HepMC /usr/local/share/HepMC
 # copy LHAPDF
 COPY --from=builder /usr/local/bin/lhapdf* /usr/local/bin/
 COPY --from=builder /usr/local/lib/libLHAPDF* /usr/local/lib/
+COPY --from=builder /usr/local/lib/python3.8/site-packages/*lhapdf* /usr/local/lib/python3.8/site-packages/
 COPY --from=builder /usr/local/include/LHAPDF /usr/local/include/LHAPDF
 COPY --from=builder /usr/local/share/LHAPDF /usr/local/share/LHAPDF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,22 @@ RUN mkdir /code && \
     cmake --build . --target install && \
     rm -rf /code
 
+# Install LHAPDF
+ARG LHAPDF_VERSION=6.3.0
+RUN mkdir /code && \
+    cd /code && \
+    wget https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz -O LHAPDF-${LHAPDF_VERSION}.tar.gz && \
+    tar xvfz LHAPDF-${LHAPDF_VERSION}.tar.gz && \
+    cd LHAPDF-${LHAPDF_VERSION} && \
+    ./configure --help && \
+    export CXX=$(which g++) && \
+    export PYTHON=$(which python) && \
+    ./configure \
+      --prefix=/usr/local && \
+    make -j$(($(nproc) - 1)) && \
+    make install && \
+    rm -rf /code
+
 # Install FastJet
 ARG FASTJET_VERSION=3.3.4
 RUN mkdir /code && \
@@ -104,6 +120,11 @@ ENV PYTHIA8DATA=/usr/local/share/Pythia8/xmldoc
 COPY --from=builder /usr/local/lib/libHepMC* /usr/local/lib/
 COPY --from=builder /usr/local/include/HepMC /usr/local/include/HepMC
 COPY --from=builder /usr/local/share/HepMC /usr/local/share/HepMC
+
+# copy LHAPDF
+COPY --from=builder /usr/local/lib/liblhapdf* /usr/local/lib/
+COPY --from=builder /usr/local/include/lhapdf /usr/local/include/lhapdf
+COPY --from=builder /usr/local/share/lhapdf /usr/local/share/lhapdf
 
 # copy FastJet
 COPY --from=builder /usr/local/bin/fastjet-config /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,9 +123,10 @@ COPY --from=builder /usr/local/include/HepMC /usr/local/include/HepMC
 COPY --from=builder /usr/local/share/HepMC /usr/local/share/HepMC
 
 # copy LHAPDF
-COPY --from=builder /usr/local/lib/liblhapdf* /usr/local/lib/
-COPY --from=builder /usr/local/include/lhapdf /usr/local/include/lhapdf
-COPY --from=builder /usr/local/share/lhapdf /usr/local/share/lhapdf
+COPY --from=builder /usr/local/bin/lhapdf* /usr/local/bin/
+COPY --from=builder /usr/local/lib/libLHAPDF* /usr/local/lib/
+COPY --from=builder /usr/local/include/LHAPDF /usr/local/include/LHAPDF
+COPY --from=builder /usr/local/share/LHAPDF /usr/local/share/LHAPDF
 
 # copy FastJet
 COPY --from=builder /usr/local/bin/fastjet-config /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ image:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=python:3.8-slim \
 	--build-arg HEPMC_VERSION=2.06.11 \
+	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg PYTHIA_VERSION=8303 \
 	--tag matthewfeickert/pythia-python:pythia8.303 \

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The Docker image contains:
 
 * Python 3.8
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
+* [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
 * [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PYTHIA 8 Docker image with Python 3, HepMC, and FastJet
+# PYTHIA 8 Docker image with Python 3 and HEP simulation stack
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/matthewfeickert/pythia-python)](https://hub.docker.com/r/matthewfeickert/pythia-python)
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/matthewfeickert/pythia-python/latest)](https://hub.docker.com/r/matthewfeickert/pythia-python/tags?name=latest)


### PR DESCRIPTION
Add LHAPDF to the Docker image

```
* Add LHAPDF v6.3.0
* Enable LHAPDF linking to PYTHIA
* Add test of the lhapdf CLI API
```