### PR TITLE
feat: Update Python and simulation stack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.8
+        tags: latest,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.9
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.8
+        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.9
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.9
+        tags: latest,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.4.0-python3.9
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.9
+        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.4.0-python3.9
         tag_with_ref: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.4.0-python3.9
+        tags: latest,pythia8.307,pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.9
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.303,pythia8.303-hepmc2.06.11-fastjet3.4.0-python3.9
+        tags: latest,latest-stable,pythia8.307,pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.9
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install PYTHIA
-ARG PYTHIA_VERSION=8303
+ARG PYTHIA_VERSION=8307
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.9-slim
+ARG BASE_IMAGE=python:3.9-slim-bullseye
 FROM ${BASE_IMAGE} as base
 
 SHELL [ "/bin/bash", "-c" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,17 @@ SHELL [ "/bin/bash", "-c" ]
 FROM base as builder
 RUN apt-get -qq -y update && \
     apt-get -qq -y install \
-        gcc \
-        g++ \
-        zlibc \
-        zlib1g-dev \
-        libbz2-dev \
-        wget \
-        make \
-        cmake \
-        rsync \
-        python3-dev \
-        sudo && \
+      gcc \
+      g++ \
+      zlib1g \
+      zlib1g-dev \
+      libbz2-dev \
+      wget \
+      make \
+      cmake \
+      rsync \
+      python3-dev \
+      sudo && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install FastJet
-ARG FASTJET_VERSION=3.3.4
+ARG FASTJET_VERSION=3.4.0
 RUN mkdir /code && \
     cd /code && \
     wget http://fastjet.fr/repo/fastjet-${FASTJET_VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir /code && \
     rm -rf /code
 
 # Install LHAPDF
-ARG LHAPDF_VERSION=6.3.0
+ARG LHAPDF_VERSION=6.5.3
 RUN mkdir /code && \
     cd /code && \
     wget https://lhapdf.hepforge.org/downloads/?f=LHAPDF-${LHAPDF_VERSION}.tar.gz -O LHAPDF-${LHAPDF_VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,11 +81,11 @@ ARG PYTHIA_VERSION=8307
 # PYTHON_VERSION already exists in the base image
 RUN mkdir /code && \
     cd /code && \
-    wget http://home.thep.lu.se/~torbjorn/pythia8/pythia${PYTHIA_VERSION}.tgz && \
+    wget --quiet "https://pythia.org/download/pythia${PYTHIA_VERSION:0:2}/pythia${PYTHIA_VERSION}.tgz" && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::-2} && \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
     ./configure \
       --prefix=/usr/local \
       --arch=Linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.8-slim
+ARG BASE_IMAGE=python:3.9-slim
 FROM ${BASE_IMAGE} as base
 
 SHELL [ "/bin/bash", "-c" ]
@@ -118,14 +118,14 @@ COPY --from=builder /usr/local/share/HepMC /usr/local/share/HepMC
 # copy LHAPDF
 COPY --from=builder /usr/local/bin/lhapdf* /usr/local/bin/
 COPY --from=builder /usr/local/lib/libLHAPDF* /usr/local/lib/
-COPY --from=builder /usr/local/lib/python3.8/site-packages/*lhapdf* /usr/local/lib/python3.8/site-packages/
+COPY --from=builder /usr/local/lib/python3.9/site-packages/*lhapdf* /usr/local/lib/python3.9/site-packages/
 COPY --from=builder /usr/local/include/LHAPDF /usr/local/include/LHAPDF
 COPY --from=builder /usr/local/share/LHAPDF /usr/local/share/LHAPDF
 
 # copy FastJet
 COPY --from=builder /usr/local/bin/fastjet-config /usr/local/bin/
 COPY --from=builder /usr/local/lib/libfastjet* /usr/local/lib/
-COPY --from=builder /usr/local/lib/python3.8/site-packages/*fastjet* /usr/local/lib/python3.8/site-packages/
+COPY --from=builder /usr/local/lib/python3.9/site-packages/*fastjet* /usr/local/lib/python3.9/site-packages/
 COPY --from=builder /usr/local/lib/libsiscone* /usr/local/lib/
 COPY --from=builder /usr/local/include/fastjet /usr/local/include/fastjet
 COPY --from=builder /usr/local/include/siscone /usr/local/include/siscone

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ image:
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg FASTJET_VERSION=3.4.0 \
-	--build-arg PYTHIA_VERSION=8303 \
-	--tag matthewfeickert/pythia-python:pythia8.303 \
-	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.11-fastjet3.4.0-python3.9 \
+	--build-arg PYTHIA_VERSION=8307 \
+	--tag matthewfeickert/pythia-python:pythia8.307 \
+	--tag matthewfeickert/pythia-python:pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.9 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ image:
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=python:3.9-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
-	--build-arg LHAPDF_VERSION=6.3.0 \
+	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg PYTHIA_VERSION=8303 \
 	--tag matthewfeickert/pythia-python:pythia8.303 \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=python:3.9-slim \
+	--build-arg BASE_IMAGE=python:3.9-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg FASTJET_VERSION=3.3.4 \

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ image:
 	--build-arg BASE_IMAGE=python:3.9-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg LHAPDF_VERSION=6.5.3 \
-	--build-arg FASTJET_VERSION=3.3.4 \
+	--build-arg FASTJET_VERSION=3.4.0 \
 	--build-arg PYTHIA_VERSION=8303 \
 	--tag matthewfeickert/pythia-python:pythia8.303 \
-	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.9 \
+	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.11-fastjet3.4.0-python3.9 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=python:3.8-slim \
+	--build-arg BASE_IMAGE=python:3.9-slim \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg LHAPDF_VERSION=6.3.0 \
 	--build-arg FASTJET_VERSION=3.3.4 \
 	--build-arg PYTHIA_VERSION=8303 \
 	--tag matthewfeickert/pythia-python:pythia8.303 \
-	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.8 \
+	--tag matthewfeickert/pythia-python:pythia8.303-hepmc2.06.11-fastjet3.3.4-python3.9 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Docker image contains:
 
 * Python 3.9
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
-* [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
+* [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.3.4`
 * [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.4.0`
-* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
+* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.307`
 
 ## Installation
 
@@ -23,7 +23,7 @@ The Docker image contains:
 - Use `docker pull` to pull down the image corresponding to the tag. For example:
 
 ```
-docker pull matthewfeickert/pythia-python:pythia8.303
+docker pull matthewfeickert/pythia-python:pythia8.307
 ```
 
 ## Use
@@ -31,14 +31,14 @@ docker pull matthewfeickert/pythia-python:pythia8.303
 You can either use the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.303 \
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.307 \
   "python tests/main01.py > main01_out_py.txt"
 ```
 
 or the original C++
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.303 \
+docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.307 \
   "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The Docker image contains:
 
-* Python 3.8
+* Python 3.9
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.3.0`
 * [FastJet](http://fastjet.fr/) `v3.3.4`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Docker image contains:
 * Python 3.9
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
-* [FastJet](http://fastjet.fr/) `v3.3.4`
+* [FastJet](http://fastjet.fr/) `v3.4.0`
 * [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.303`
 
 ## Installation


### PR DESCRIPTION
```
* Update to Python 3.9.
* Update base image to specify Debian bullseye for OS stability.
* Update LHAPDF to v6.5.3.
* Update FastJet to v3.4.0.
* Update PYTHIA to v8.307.
```