### PR TITLE
feat: Use a default Python virtual environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        "g++ tests/test_FastJet.cc -o tests/test_FastJet \$(/usr/local/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet"
+        "g++ tests/test_FastJet.cc -o tests/test_FastJet \$(/usr/local/venv/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet"
     - name: Test FastJet Python
       run: >-
         docker run --rm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt";
+        "g++ tests/main01.cc -pthread -o tests/main01 \$(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt";
         wc main01_out_cpp.txt
     - name: Run test program in Python
       run: >-
@@ -47,7 +47,7 @@ jobs:
         -v $PWD:$PWD
         -w $PWD
         matthewfeickert/pythia-python:test
-        "g++ tests/main42.cc -o tests/main42 -lpythia8 -lHepMC -ldl; ./tests/main42 tests/main42.cmnd main42_out.hepmc"
+        "g++ tests/main42.cc -pthread -o tests/main42 \$(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc"
         wc main42_out.hepmc
     - name: Test LHAPDF CLI
       run: >-

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,33 +117,8 @@ RUN apt-get -qq -y update && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt-get/lists/*
 
-# copy HepMC
-COPY --from=builder /usr/local/lib/libHepMC* /usr/local/lib/
-COPY --from=builder /usr/local/include/HepMC /usr/local/include/HepMC
-COPY --from=builder /usr/local/share/HepMC /usr/local/share/HepMC
-
-# copy LHAPDF
-COPY --from=builder /usr/local/bin/lhapdf* /usr/local/bin/
-COPY --from=builder /usr/local/lib/libLHAPDF* /usr/local/lib/
-COPY --from=builder /usr/local/lib/python3.9/site-packages/*lhapdf* /usr/local/lib/python3.9/site-packages/
-COPY --from=builder /usr/local/include/LHAPDF /usr/local/include/LHAPDF
-COPY --from=builder /usr/local/share/LHAPDF /usr/local/share/LHAPDF
-
-# copy FastJet
-COPY --from=builder /usr/local/bin/fastjet-config /usr/local/bin/
-COPY --from=builder /usr/local/lib/libfastjet* /usr/local/lib/
-COPY --from=builder /usr/local/lib/python3.9/site-packages/*fastjet* /usr/local/lib/python3.9/site-packages/
-COPY --from=builder /usr/local/lib/libsiscone* /usr/local/lib/
-COPY --from=builder /usr/local/include/fastjet /usr/local/include/fastjet
-COPY --from=builder /usr/local/include/siscone /usr/local/include/siscone
-
-# copy PYTHIA
-COPY --from=builder /usr/local/bin/pythia8-config /usr/local/bin/
-COPY --from=builder /usr/local/lib/libpythia8* /usr/local/lib/
-COPY --from=builder /usr/local/lib/pythia8.so /usr/local/lib/
-COPY --from=builder /usr/local/include/Pythia8 /usr/local/include/Pythia8
-COPY --from=builder /usr/local/include/Pythia8Plugins /usr/local/include/Pythia8Plugins
-COPY --from=builder /usr/local/share/Pythia8 /usr/local/share/Pythia8
+# copy from builder
+COPY --from=builder /usr/local/venv /usr/local/venv
 
 WORKDIR /home/data
 ENV HOME /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,17 +129,16 @@ RUN apt-get -qq -y update && \
       python3-dev && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc && \
+    cp /root/.bashrc /etc/.bashrc && \
+    echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile
 
 # copy from builder
 COPY --from=builder /usr/local/venv /usr/local/venv
 
 WORKDIR /home/data
 ENV HOME /home
-
-RUN printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc && \
-    cp /root/.bashrc /etc/.bashrc && \
-    echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,10 @@ COPY --from=builder /usr/local/venv /usr/local/venv
 WORKDIR /home/data
 ENV HOME /home
 
+RUN printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc && \
+    cp /root/.bashrc /etc/.bashrc && \
+    echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile
+
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/* && \
     python -m venv /usr/local/venv && \
     . /usr/local/venv/bin/activate && \
-    python -m pip --no-cache-dir install pip setuptools wheel && \
+    python -m pip --no-cache-dir install --upgrade pip setuptools wheel && \
     python -m pip list
 
 # Install HepMC
@@ -113,6 +113,8 @@ RUN mkdir /code && \
     rm -rf /code
 
 FROM base
+
+ENV PATH=/usr/local/venv/bin:"${PATH}"
 RUN apt-get -qq -y update && \
     apt-get -qq -y install \
         g++ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,11 +74,12 @@ RUN mkdir /code && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
     export CXX=$(which g++) && \
-    export PYTHON=$(which python) && \
+    export PYTHON=$(command -v python) && \
+    export PYTHON_CONFIG=$(find /usr/local/ -iname "python-config.py") && \
     ./configure \
       --prefix=/usr/local/venv \
       --enable-pyext=yes && \
-    make -j$(($(nproc) - 1)) && \
+    make -j$(nproc --ignore=1) && \
     make check && \
     make install && \
     rm -rf /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,17 +95,20 @@ RUN mkdir /code && \
     ./configure --help && \
     export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
     ./configure \
-      --prefix=/usr/local \
+      --prefix=/usr/local/venv \
       --arch=Linux \
       --cxx=g++ \
+      --enable-64bit \
       --with-gzip \
       --with-hepmc2=/usr/local/venv \
       --with-lhapdf6=/usr/local/venv \
       --with-fastjet3=/usr/local/venv \
       --with-python-bin=/usr/local/venv/bin/ \
       --with-python-lib=/usr/local/venv/lib/python${PYTHON_MINOR_VERSION} \
-      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} && \
-    make -j$(($(nproc) - 1)) && \
+      --with-python-include=/usr/local/include/python${PYTHON_MINOR_VERSION} \
+      --cxx-common="-O2 -m64 -pedantic -W -Wall -Wshadow -fPIC -std=c++17" \
+      --cxx-shared="-shared -std=c++17" && \
+    make -j$(nproc --ignore=1) && \
     make install && \
     rm -rf /code
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,12 +116,20 @@ FROM base
 
 ENV PATH=/usr/local/venv/bin:"${PATH}"
 RUN apt-get -qq -y update && \
-    apt-get -qq -y install \
-        g++ \
-        make && \
+    apt-get -qq -y install --no-install-recommends \
+      gcc \
+      g++ \
+      zlib1g \
+      zlib1g-dev \
+      libbz2-dev \
+      wget \
+      make \
+      cmake \
+      rsync \
+      python3-dev && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 # copy from builder
 COPY --from=builder /usr/local/venv /usr/local/venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,6 @@ RUN mkdir /code && \
     wget http://hepmc.web.cern.ch/hepmc/releases/hepmc${HEPMC_VERSION}.tgz && \
     tar xvfz hepmc${HEPMC_VERSION}.tgz && \
     mv HepMC-${HEPMC_VERSION} src && \
-    mkdir build && \
-    cd build && \
     cmake \
       -DCMAKE_CXX_COMPILER=$(which g++) \
       -DCMAKE_BUILD_TYPE=Release \
@@ -44,9 +42,11 @@ RUN mkdir /code && \
       -Dmomentum:STRING=MEV \
       -Dlength:STRING=MM \
       -DCMAKE_INSTALL_PREFIX=/usr/local/venv \
-      ../src && \
-    cmake --build . -- -j$(($(nproc) - 1)) && \
-    cmake --build . --target install && \
+      -S src \
+      -B build && \
+    cmake build -L && \
+    cmake --build build --parallel $(nproc --ignore=1) && \
+    cmake --build build --target install && \
     rm -rf /code
 
 # Install LHAPDF
@@ -61,7 +61,7 @@ RUN mkdir /code && \
     export PYTHON=$(which python) && \
     ./configure \
       --prefix=/usr/local/venv && \
-    make -j$(($(nproc) - 1)) && \
+    make -j$(nproc --ignore=1) && \
     make install && \
     rm -rf /code
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		"g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+		'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt'
 	wc main01_out_cpp.txt
 	docker run \
 		--rm \
@@ -39,4 +39,4 @@ test_hepmc:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		"g++ tests/main42.cc -o tests/main42 -lpythia8 -lHepMC -ldl; ./tests/main42 tests/main42.cmnd main42_out.hepmc"
+		"g++ tests/main42.cc -pthread -o tests/main42 $(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt'
+		'g++ tests/main01.cc -pthread -o tests/main01 $$(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt'
 	wc main01_out_cpp.txt
 	docker run \
 		--rm \
@@ -39,4 +39,4 @@ test_hepmc:
 		-v $(shell pwd):$(shell pwd) \
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
-		"g++ tests/main42.cc -pthread -o tests/main42 $(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc"
+		'g++ tests/main42.cc -pthread -o tests/main42 $$(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'

--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,11 @@ test_hepmc:
 		-w $(shell pwd) \
 		matthewfeickert/pythia-python:latest \
 		'g++ tests/main42.cc -pthread -o tests/main42 $$(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
+
+test_fastjet:
+	docker run \
+		--rm \
+		-v $(shell pwd):$(shell pwd) \
+		-w $(shell pwd) \
+		matthewfeickert/pythia-python:latest \
+        'g++ tests/test_FastJet.cc -o tests/test_FastJet $$(/usr/local/venv/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'


### PR DESCRIPTION
```
* Use a default Python virtual environment under /usr/local/venv/
  and add /usr/local/venv/bin to PATH to automatically activate the
  virtual environment at runtime.
* Simplify COPY by COPYing /usr/local/venv in full.
* Use a /etc/.bashrc to load environment from /etc/profile on login shell.
* Use nproc's '--ignore' flag to 'exclude N processing units' which is
  more standard and readable than the current implementation.
* Specify '--with-X' option paths for PYTHIA.
* Add -pthread option to examples to build successfully.
* Use $(pythia8-config --cxxflags --ldflags) to determine includes and load statements
  for PYTHIA8.
```