### PR TITLE
feat: Use Scikit-HEP fastjet library to provide fastjet Python API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,8 +133,7 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/* && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc && \
     cp /root/.bashrc /etc/.bashrc && \
-    echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile && \
-    ln --symbolic $(find /usr/local/venv/ -type f -iname "fastjet-config") /usr/local/venv/bin/
+    echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile
 
 WORKDIR /home/data
 ENV HOME /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ RUN apt-get -qq -y update && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc && \
     cp /root/.bashrc /etc/.bashrc && \
     echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile && \
-    ln --symbolic $(find /usr/local/venv/ -type f -iname "fastjet-config") /venv/bin/
+    ln --symbolic $(find /usr/local/venv/ -type f -iname "fastjet-config") /usr/local/venv/bin/
 
 WORKDIR /home/data
 ENV HOME /home


### PR DESCRIPTION
* Install a compatible release of scikit-hep/fastjet from PyPI to provide the FastJet Python API.
   - https://github.com/scikit-hep/fastjet provides more modern and Pythonic API options.
   - c.f. https://github.com/scikit-hep/fastjet/issues/148 for why installing FastJet from source is still required for C++ usage.
* Make the COPY from the builder container the first step in the second stage of the build.

```
* Install a compatible release of scikit-hep/fastjet from PyPI to provide the FastJet
  Python API.
   - https://github.com/scikit-hep/fastjet provides more modern and Pythonic
     API options.
   - c.f. https://github.com/scikit-hep/fastjet/issues/148 for why installing FastJet from
     source is still required for C++ usage.
* Make the COPY from the builder container the first step in the second stage of the build.
```