### PR TITLE
feat: Add default non-root user 'docker'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,23 @@ jobs:
     - name: Run test program in C++
       run: >-
         docker run --rm
-        -v $PWD:$PWD
-        -w $PWD
+        --volume $PWD:/work
         matthewfeickert/pythia-python:test
-        "g++ tests/main01.cc -pthread -o tests/main01 \$(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt";
+        'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt';
         wc main01_out_cpp.txt
     - name: Run test program in Python
       run: >-
         docker run --rm
-        -v $PWD:$PWD
-        -w $PWD
+        --volume $PWD:/work
         matthewfeickert/pythia-python:test
         "python tests/main01.py > main01_out_py.txt";
         wc main01_out_py.txt
     - name: Test HepMC
       run: >-
         docker run --rm
-        -v $PWD:$PWD
-        -w $PWD
+        --volume $PWD:/work
         matthewfeickert/pythia-python:test
-        "g++ tests/main42.cc -pthread -o tests/main42 \$(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc"
+        'g++ tests/main42.cc -pthread -o tests/main42 $(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
         wc main42_out.hepmc
     - name: Test LHAPDF CLI
       run: >-
@@ -57,14 +54,12 @@ jobs:
     - name: Test FastJet
       run: >-
         docker run --rm
-        -v $PWD:$PWD
-        -w $PWD
+        --volume $PWD:/work
         matthewfeickert/pythia-python:test
-        "g++ tests/test_FastJet.cc -o tests/test_FastJet \$(/usr/local/venv/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet"
+        'g++ tests/test_FastJet.cc -o tests/test_FastJet $(fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'
     - name: Test FastJet Python
       run: >-
         docker run --rm
-        -v $PWD:$PWD
-        -w $PWD
+        --volume $PWD:/work
         matthewfeickert/pythia-python:test
         "python tests/test_FastJet.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Run test program in C++
       run: >-
         docker run --rm
+        --user $(id --user $USER):$(id --group)
         --volume $PWD:/work
         matthewfeickert/pythia-python:test
         'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt';
@@ -35,6 +36,7 @@ jobs:
     - name: Run test program in Python
       run: >-
         docker run --rm
+        --user $(id --user $USER):$(id --group)
         --volume $PWD:/work
         matthewfeickert/pythia-python:test
         "python tests/main01.py > main01_out_py.txt";
@@ -42,6 +44,7 @@ jobs:
     - name: Test HepMC
       run: >-
         docker run --rm
+        --user $(id --user $USER):$(id --group)
         --volume $PWD:/work
         matthewfeickert/pythia-python:test
         'g++ tests/main42.cc -pthread -o tests/main42 $(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
@@ -54,12 +57,14 @@ jobs:
     - name: Test FastJet
       run: >-
         docker run --rm
+        --user $(id --user $USER):$(id --group)
         --volume $PWD:/work
         matthewfeickert/pythia-python:test
         'g++ tests/test_FastJet.cc -o tests/test_FastJet $(fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'
     - name: Test FastJet Python
       run: >-
         docker run --rm
+        --user $(id --user $USER):$(id --group)
         --volume $PWD:/work
         matthewfeickert/pythia-python:test
         "python tests/test_FastJet.py"

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,8 @@ RUN mkdir /code && \
 
 FROM base
 
+SHELL [ "/bin/bash", "-c" ]
+
 # copy from builder
 COPY --from=builder /usr/local/venv /usr/local/venv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,9 +165,6 @@ RUN apt-get -qq -y update && \
     chmod -R 777 /usr/local/venv && \
     echo "SHELL=/bin/bash" >> /etc/environment
 
-WORKDIR /home/data
-ENV HOME /home
-
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,15 @@ run:
 test:
 	docker run \
 		--rm \
-		-v $(shell pwd):$(shell pwd) \
-		-w $(shell pwd) \
+		--user $(shell id --user $(USER)):$(shell id --group) \
+		--volume $(shell pwd):/work \
 		matthewfeickert/pythia-python:latest \
 		'g++ tests/main01.cc -pthread -o tests/main01 $$(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt'
 	wc main01_out_cpp.txt
 	docker run \
 		--rm \
-		-v $(shell pwd):$(shell pwd) \
-		-w $(shell pwd) \
+		--user $(shell id --user $(USER)):$(shell id --group) \
+		--volume $(shell pwd):/work \
 		matthewfeickert/pythia-python:latest \
 		"python tests/main01.py > main01_out_py.txt"
 	wc main01_out_py.txt
@@ -36,15 +36,15 @@ test:
 test_hepmc:
 	docker run \
 		--rm \
-		-v $(shell pwd):$(shell pwd) \
-		-w $(shell pwd) \
+		--user $(shell id --user $(USER)):$(shell id --group) \
+		--volume $(shell pwd):/work \
 		matthewfeickert/pythia-python:latest \
 		'g++ tests/main42.cc -pthread -o tests/main42 $$(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
 
 test_fastjet:
 	docker run \
 		--rm \
-		-v $(shell pwd):$(shell pwd) \
-		-w $(shell pwd) \
+		--user $(shell id --user $(USER)):$(shell id --group) \
+		--volume $(shell pwd):/work \
 		matthewfeickert/pythia-python:latest \
-        'g++ tests/test_FastJet.cc -o tests/test_FastJet $$(/usr/local/venv/bin/fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'
+        'g++ tests/test_FastJet.cc -o tests/test_FastJet $$(fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'

--- a/README.md
+++ b/README.md
@@ -31,14 +31,22 @@ docker pull matthewfeickert/pythia-python:pythia8.307
 You can either use the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
-docker run --rm -v $PWD:/work matthewfeickert/pythia-python:pythia8.307 \
-  "python tests/main01.py > main01_out_py.txt"
+docker run \
+  --rm \
+  --user $(id --user $USER):$(id --group) \
+  --volume $PWD:/work \
+  matthewfeickert/pythia-python:pythia8.307 \
+  'python tests/main01.py > main01_out_py.txt'
 ```
 
 or the original C++
 
 ```
-docker run --rm -v $PWD:/work matthewfeickert/pythia-python:pythia8.307 \
+docker run \
+  --rm \
+  --user $(id --user $USER):$(id --group) \
+  --volume $PWD:/work \
+  matthewfeickert/pythia-python:pythia8.307 \
   'g++ tests/main01.cc -o tests/main01 $(pythia8-config --ldflags); ./tests/main01 > main01_out_cpp.txt'
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ docker pull matthewfeickert/pythia-python:pythia8.307
 You can either use the image as "`PYTHIA` as a service", as demoed here with the test script in the repo using the Python bindings
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.307 \
+docker run --rm -v $PWD:/work matthewfeickert/pythia-python:pythia8.307 \
   "python tests/main01.py > main01_out_py.txt"
 ```
 
 or the original C++
 
 ```
-docker run --rm -v $PWD:$PWD -w $PWD matthewfeickert/pythia-python:pythia8.307 \
-  "g++ tests/main01.cc -o tests/main01 -lpythia8 -ldl; ./tests/main01 > main01_out_cpp.txt"
+docker run --rm -v $PWD:/work matthewfeickert/pythia-python:pythia8.307 \
+  'g++ tests/main01.cc -o tests/main01 $(pythia8-config --ldflags); ./tests/main01 > main01_out_cpp.txt'
 ```
 
 or you can run interactively


### PR DESCRIPTION
```
* Make the default user be non-root user 'docker'.
* Set workdir to /work.
* Add universal write permissions to  /usr/local/venv and common directories.
* Update README, Makefile, and CI to use '--user $(id --user $USER):$(id --group)'
  pattern to properly give user permissions at runtime.
```