### PR TITLE
feat: Update to Python 3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.307,pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.9
+        tags: latest,pythia8.307,pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.10
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.307,pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.9
+        tags: latest,latest-stable,pythia8.307,pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.10
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ RUN mkdir /code && \
     tar xvfz pythia${PYTHIA_VERSION}.tgz && \
     cd pythia${PYTHIA_VERSION} && \
     ./configure --help && \
-    export PYTHON_MINOR_VERSION=${PYTHON_VERSION::3} && \
+    export PYTHON_MINOR_VERSION=${PYTHON_VERSION%.*} && \
     ./configure \
       --prefix=/usr/local/venv \
       --arch=Linux \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get -qq -y update && \
       make \
       cmake \
       rsync \
-      python3-dev \
       libboost-all-dev && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq -y update && \
       zlib1g-dev \
       libbz2-dev \
       wget \
+      curl \
       make \
       cmake \
       rsync \
@@ -35,7 +36,7 @@ RUN mkdir /code && \
     tar xvfz hepmc${HEPMC_VERSION}.tgz && \
     mv HepMC-${HEPMC_VERSION} src && \
     cmake \
-      -DCMAKE_CXX_COMPILER=$(which g++) \
+      -DCMAKE_CXX_COMPILER=$(command -v g++) \
       -DCMAKE_BUILD_TYPE=Release \
       -Dbuild_docs:BOOL=OFF \
       -Dmomentum:STRING=MEV \
@@ -56,8 +57,8 @@ RUN mkdir /code && \
     tar xvfz LHAPDF-${LHAPDF_VERSION}.tar.gz && \
     cd LHAPDF-${LHAPDF_VERSION} && \
     ./configure --help && \
-    export CXX=$(which g++) && \
-    export PYTHON=$(which python) && \
+    export CXX=$(command -v g++) && \
+    export PYTHON=$(command -v python) && \
     ./configure \
       --prefix=/usr/local/venv && \
     make -j$(nproc --ignore=1) && \
@@ -72,7 +73,7 @@ RUN mkdir /code && \
     tar xvfz fastjet-${FASTJET_VERSION}.tar.gz && \
     cd fastjet-${FASTJET_VERSION} && \
     ./configure --help && \
-    export CXX=$(which g++) && \
+    export CXX=$(command -v g++) && \
     ./configure \
       --prefix=/usr/local/venv && \
     make -j$(nproc --ignore=1) && \
@@ -140,10 +141,10 @@ RUN apt-get -qq -y update && \
       zlib1g-dev \
       libbz2-dev \
       wget \
+      curl \
       make \
       cmake \
       rsync \
-      python3-dev \
       libboost-all-dev && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=python:3.9-slim-bullseye
+ARG BASE_IMAGE=python:3.10-slim-bullseye
 FROM ${BASE_IMAGE} as base
 
 SHELL [ "/bin/bash", "-c" ]

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ all: image
 image:
 	docker build . \
 	-f Dockerfile \
-	--build-arg BASE_IMAGE=python:3.9-slim-bullseye \
+	--build-arg BASE_IMAGE=python:3.10-slim-bullseye \
 	--build-arg HEPMC_VERSION=2.06.11 \
 	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg FASTJET_VERSION=3.4.0 \
 	--build-arg PYTHIA_VERSION=8307 \
 	--tag matthewfeickert/pythia-python:pythia8.307 \
-	--tag matthewfeickert/pythia-python:pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.9 \
+	--tag matthewfeickert/pythia-python:pythia8.307-hepmc2.06.11-fastjet3.4.0-python3.10 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > PYTHIA is a program for the generation of high-energy physics events, i.e. for the description of collisions at high energies between elementary particles such as e+, e-, p and pbar in various combinations.
 
-`PYTHIA` 8's source is [distributed on GitLab](https://gitlab.com/Pythia8/releases) and is a product of the [`PYTHIA` development team](http://home.thep.lu.se/~torbjorn/Pythia.html).
+`PYTHIA` 8's source is [distributed on GitLab](https://gitlab.com/Pythia8/releases) and is a product of the [`PYTHIA` development team](https://pythia.org/).
 
 ## Distributed Software
 
@@ -33,7 +33,7 @@ You can either use the image as "`PYTHIA` as a service", as demoed here with the
 ```
 docker run \
   --rm \
-  --user $(id --user $USER):$(id --group) \
+  --user $(id -u $USER):$(id -g) \
   --volume $PWD:/work \
   matthewfeickert/pythia-python:pythia8.307 \
   'python tests/main01.py > main01_out_py.txt'
@@ -44,7 +44,7 @@ or the original C++
 ```
 docker run \
   --rm \
-  --user $(id --user $USER):$(id --group) \
+  --user $(id -u $USER):$(id -g) \
   --volume $PWD:/work \
   matthewfeickert/pythia-python:pythia8.307 \
   'g++ tests/main01.cc -o tests/main01 $(pythia8-config --ldflags); ./tests/main01 > main01_out_cpp.txt'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Docker image contains:
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.4.0`
-* [PYTHIA](http://home.thep.lu.se/~torbjorn/Pythia.html) `v8.307`
+* [PYTHIA](https://pythia.org/) `v8.307`
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 The Docker image contains:
 
-* Python 3.9
+* Python 3.10
 * [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.4.0`


### PR DESCRIPTION
```
* Update to Python 3.10.
* Use ${PYTHON_VERSION%.*} to properly get Python minor version info.
* Add curl.
* Remove python3-dev from apt-get dependencies. The python Docker images
  already contain the Python.h header files and having multiple can
  potentially result in conflicts during builds.
* Use 'command -v' over 'which' for generality.
* Use modern PYTHIA website URL: https://pythia.org/
* Use GNU and Unix safe versions of id options:
  $(id -u $USER):$(id -g)
```