### PR TITLE
docs: Add compiler flags in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can either use the image as "`PYTHIA` as a service", as demoed here with the
 ```
 docker run \
   --rm \
-  --user $(id -u $USER):$(id -g) \
+  --user $(id -u $USER):$(id -g $USER) \
   --volume $PWD:/work \
   matthewfeickert/pythia-python:pythia8.308 \
   'python tests/main01.py > main01_out_py.txt'
@@ -44,7 +44,7 @@ or the original C++
 ```
 docker run \
   --rm \
-  --user $(id -u $USER):$(id -g) \
+  --user $(id -u $USER):$(id -g $USER) \
   --volume $PWD:/work \
   matthewfeickert/pythia-python:pythia8.308 \
   'g++ tests/main01.cc -o tests/main01 $(pythia8-config --ldflags); ./tests/main01 > main01_out_cpp.txt'

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker run \
   --user $(id -u $USER):$(id -g $USER) \
   --volume $PWD:/work \
   matthewfeickert/pythia-python:pythia8.308 \
-  'g++ tests/main01.cc -o tests/main01 $(pythia8-config --ldflags); ./tests/main01 > main01_out_cpp.txt'
+  'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt'
 ```
 
 or you can run interactively


### PR DESCRIPTION
```
* Add '-pthread' and '$(pythia8-config --cxxflags)' to C++ example in the
  README to allow for compilation to proceed.
* Add missing '$USER' to 'id -g' to make it explicit which user info is used.
```