### PR TITLE
feat: Add Binder support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,8 @@ test_fastjet:
 		--volume $(shell pwd):/work \
 		matthewfeickert/pythia-python:latest \
         'g++ tests/test_FastJet.cc -o tests/test_FastJet $$(fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'
+
+binder_repo2docker:
+	repo2docker \
+	--image-name matthewfeickert/pythia-python:binder \
+	.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/matthewfeickert/pythia-python)](https://hub.docker.com/r/matthewfeickert/pythia-python)
 [![Docker Image Size (tag)](https://img.shields.io/docker/image-size/matthewfeickert/pythia-python/latest)](https://hub.docker.com/r/matthewfeickert/pythia-python/tags?name=latest)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/matthewfeickert/pythia-python/HEAD)
 
 > PYTHIA is a program for the generation of high-energy physics events, i.e. for the description of collisions at high energies between elementary particles such as e+, e-, p and pbar in various combinations.
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -6,6 +6,9 @@ FROM matthewfeickert/pythia-python:pythia8.308
 USER root
 RUN deluser docker
 
+# DEBUG
+RUN printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /etc/profile
+
 ARG NB_USER=jovyan
 ARG NB_UID=1000
 ENV USER ${NB_USER}
@@ -21,8 +24,6 @@ USER ${NB_USER}
 
 # Allow to use the repository with an authenticated Binder
 RUN python -m pip install --no-cache-dir jupyterhub
-
-RUN printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /etc/profile
 
 # Make sure the contents of the repo are in ${HOME}
 COPY . ${HOME}

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -3,11 +3,10 @@ FROM matthewfeickert/pythia-python:pythia8.308
 
 # Remove exisiting non-root user "docker" with uid 1000
 # to avoid conflict with jovyan
+# Install necessary jupyter dependencies
 USER root
-RUN deluser docker
-
-# DEBUG
-RUN printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /etc/profile
+RUN deluser docker && \
+    python -m pip install --no-cache-dir jupyter jupyterlab
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,54 @@
+# c.f. https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile
+FROM matthewfeickert/pythia-python:pythia8.308
+
+# Remove exisiting non-root user "docker" with uid 1000
+# to avoid conflict with jovyan
+USER root
+RUN deluser docker
+
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ENV USER ${NB_USER}
+ENV NB_UID ${NB_UID}
+ENV HOME /home/${NB_USER}
+
+USER root
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+USER ${NB_USER}
+
+# Allow to use the repository with an authenticated Binder
+RUN python -m pip install --no-cache-dir jupyterhub
+
+# Make sure the contents of the repo are in ${HOME}
+COPY . ${HOME}
+USER root
+RUN chown -R ${NB_UID} ${HOME} && \
+    chown -R ${NB_UID} /usr/local/venv
+USER ${NB_USER}
+WORKDIR ${HOME}
+
+ENTRYPOINT [ ]
+CMD [ ]
+
+
+# Stuck on getting things working with no password
+# https://jupyter-notebook.readthedocs.io/en/stable/public_server.html
+# docker build --file binder/Dockerfile -t matthewfeickert/pythia-python:binder .
+
+# FAIL:
+# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter notebook --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
+
+# PASS:
+# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
+
+# PASS:
+# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
+
+# PASS:
+# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter notebook --ip=0.0.0.0 --port=8888
+
+# FAIL:
+# repo2docker .

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -21,7 +21,11 @@ USER ${NB_USER}
 # FIXME: Downgrade jupyter-server to contend with:
 # https://github.com/jupyterhub/repo2docker/issues/1231
 # https://github.com/jupyter-server/jupyter_server/issues/1038
-RUN python -m pip --no-cache-dir install --upgrade 'jupyter-server<2.0.0'
+RUN python -m pip --no-cache-dir install --upgrade \
+    notebook \
+    jupyterlab \
+    jupyterhub \
+    'jupyter-server<2.0.0'
 
 # Make sure the contents of the repo are in ${HOME}
 COPY . ${HOME}

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -3,10 +3,8 @@ FROM matthewfeickert/pythia-python:pythia8.308
 
 # Remove exisiting non-root user "docker" with uid 1000
 # to avoid conflict with jovyan
-# Install necessary jupyter dependencies
 USER root
-RUN deluser docker && \
-    python -m pip install --no-cache-dir jupyter jupyterlab
+RUN deluser docker
 
 ARG NB_USER=jovyan
 ARG NB_UID=1000
@@ -21,9 +19,6 @@ RUN adduser --disabled-password \
     ${NB_USER}
 USER ${NB_USER}
 
-# Allow to use the repository with an authenticated Binder
-RUN python -m pip install --no-cache-dir jupyterhub
-
 # Make sure the contents of the repo are in ${HOME}
 COPY . ${HOME}
 USER root
@@ -31,6 +26,10 @@ RUN chown -R ${NB_UID} ${HOME} && \
     chown -R ${NB_UID} /usr/local/venv
 USER ${NB_USER}
 WORKDIR ${HOME}
+
+# Install necessary jupyter dependencies
+# Install jupyterhub to allow use of the repository with an authenticated Binder
+RUN python -m pip install --no-cache-dir jupyter jupyterlab jupyterhub
 
 ENTRYPOINT [ ]
 CMD [ ]

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -46,7 +46,7 @@ CMD [ ]
 # docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
 
 # PASS:
-# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
+# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --ip=0.0.0.0 --port=8888
 
 # PASS:
 # docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter notebook --ip=0.0.0.0 --port=8888

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,11 +1,10 @@
-# c.f. https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile
 FROM matthewfeickert/pythia-python:pythia8.308
 
-# Remove exisiting non-root user "docker" with uid 1000 to avoid conflict with NB_USER
+# Remove existing non-root user "docker" with uid 1000
+# to avoid conflict with jovyan
 USER root
 RUN deluser docker
 
-# Add default user NB_USER
 ARG NB_USER=jovyan
 ARG NB_UID=1000
 ENV USER ${NB_USER}
@@ -19,6 +18,11 @@ RUN adduser --disabled-password \
     ${NB_USER}
 USER ${NB_USER}
 
+# FIXME: Downgrade jupyter-server to contend with:
+# https://github.com/jupyterhub/repo2docker/issues/1231
+# https://github.com/jupyter-server/jupyter_server/issues/1038
+RUN python -m pip --no-cache-dir install --upgrade 'jupyter-server<2.0.0'
+
 # Make sure the contents of the repo are in ${HOME}
 COPY . ${HOME}
 USER root
@@ -27,29 +31,6 @@ RUN chown -R ${NB_UID} ${HOME} && \
 USER ${NB_USER}
 WORKDIR ${HOME}
 
-# Install necessary jupyter dependencies
-# Install jupyterhub to allow use of the repository with an authenticated Binder
-RUN python -m pip install --no-cache-dir jupyter jupyterlab jupyterhub
-
+# Null out ENTRYPOINT and CMD to let repo2docker control them
 ENTRYPOINT [ ]
 CMD [ ]
-
-
-# Stuck on getting things working with no password
-# https://jupyter-notebook.readthedocs.io/en/stable/public_server.html
-# docker build --file binder/Dockerfile -t matthewfeickert/pythia-python:binder .
-
-# FAIL:
-# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter notebook --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
-
-# PASS:
-# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --NotebookApp.default_url=/lab/ --ip=0.0.0.0 --port=8888
-
-# PASS:
-# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter lab --ip=0.0.0.0 --port=8888
-
-# PASS:
-# docker run -it --rm -p 8888:8888 matthewfeickert/pythia-python:binder jupyter notebook --ip=0.0.0.0 --port=8888
-
-# FAIL:
-# repo2docker .

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -22,6 +22,8 @@ USER ${NB_USER}
 # Allow to use the repository with an authenticated Binder
 RUN python -m pip install --no-cache-dir jupyterhub
 
+RUN printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /etc/profile
+
 # Make sure the contents of the repo are in ${HOME}
 COPY . ${HOME}
 USER root

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,11 +1,11 @@
 # c.f. https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile
 FROM matthewfeickert/pythia-python:pythia8.308
 
-# Remove exisiting non-root user "docker" with uid 1000
-# to avoid conflict with jovyan
+# Remove exisiting non-root user "docker" with uid 1000 to avoid conflict with NB_USER
 USER root
 RUN deluser docker
 
+# Add default user NB_USER
 ARG NB_USER=jovyan
 ARG NB_UID=1000
 ENV USER ${NB_USER}


### PR DESCRIPTION
Add Dockerfile with workaround for https://github.com/jupyterhub/repo2docker/issues/1231 and https://github.com/jupyter-server/jupyter_server/issues/1038.

```
* Add minimal Dockerfile for repo2docker to build and launch successfully
  from matthewfeickert/pythia-python:pythia8.308.
   - Constrain 'jupyter-server<2.0.0' to avoid
     https://github.com/jupyterhub/repo2docker/issues/1231 and
     https://github.com/jupyter-server/jupyter_server/issues/1038
* Add binder_repo2docker Make target for local building with repo2docker.
* Add Binder launch badge to README.
```