### PR TITLE
feat: Add example notebook and jupytext support

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -34,7 +34,8 @@ RUN python -m pip --no-cache-dir install --upgrade \
 COPY . ${HOME}
 USER root
 RUN chown -R ${NB_UID} ${HOME} && \
-    chown -R ${NB_UID} /usr/local/venv
+    chown -R ${NB_UID} /usr/local/venv && \
+    find "${HOME}/examples" -type f -iname "*.py" | xargs jupytext --to notebook
 USER ${NB_USER}
 WORKDIR ${HOME}
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -25,7 +25,10 @@ RUN python -m pip --no-cache-dir install --upgrade \
     notebook \
     jupyterlab \
     jupyterhub \
-    'jupyter-server<2.0.0'
+    'jupyter-server<2.0.0' \
+    matplotlib \
+    ipympl \
+    jupytext
 
 # Make sure the contents of the repo are in ${HOME}
 COPY . ${HOME}

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -30,12 +30,13 @@ RUN python -m pip --no-cache-dir install --upgrade \
     ipympl \
     jupytext
 
-# Make sure the contents of the repo are in ${HOME}
+# Make sure the contents of the repo are in ${HOME} and that
+# NB_UID owns all files it should control
 COPY . ${HOME}
 USER root
-RUN chown -R ${NB_UID} ${HOME} && \
-    chown -R ${NB_UID} /usr/local/venv && \
-    find "${HOME}/examples" -type f -iname "*.py" | xargs jupytext --to notebook
+RUN find "${HOME}/examples" -type f -iname "*.py" | xargs jupytext --to notebook && \
+    chown -R ${NB_UID} ${HOME} && \
+    chown -R ${NB_UID} /usr/local/venv
 USER ${NB_USER}
 WORKDIR ${HOME}
 

--- a/examples/pythia_docs.py
+++ b/examples/pythia_docs.py
@@ -1,0 +1,115 @@
+# ---
+# jupyter:
+#   jupytext:
+#     notebook_metadata_filter: all,-jupytext.text_representation.jupytext_version
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.10.9
+# ---
+
+# %%
+# %matplotlib widget
+
+# %%
+# https://pythia.org/download/pdf/pythia8300.pdf
+# Section: 10.4.1 PYTHON interface
+# with corrections for typos and wrong Python code in the docs
+import matplotlib.pyplot as plt
+import numpy as np
+import pythia8
+
+
+# %%
+# Wrapper around numpy histogram to allow fill functionality.
+class HistoFiller(object):
+    def __init__(self, bins):
+        self.bins = bins
+        self.hist, edges = np.histogram([], bins=bins, weights=[])
+        self.widths = [edges[i + 1] - edges[i] for i in range(len(edges) - 1)]
+
+    def fill(self, val, w=1.0):
+        hist, edges = np.histogram(val, bins=self.bins, weights=w)
+        self.hist += hist
+
+    def get(self):
+        scale = 1.0 / sum(self.hist)
+        return [h / w * scale for h, w in zip(self.hist, self.widths)], [
+            np.sqrt(h) * scale for h in self.hist
+        ]
+
+
+# %% [markdown]
+# Set up and configure Pythia
+
+# %%
+pythia = pythia8.Pythia()
+pythia.readString("SoftQCD:all = on")
+
+# %% [markdown]
+# Initialize the generator
+
+# %%
+pythia.init()
+
+# %% [markdown]
+# Declare the histogram
+
+# %%
+bin_width = 3.0
+bins = [bin_width * x for x in range(20)]
+multiparton_hist = HistoFiller(bins)
+
+# %% [markdown]
+# Event loop. Find particles and fill histogram.
+
+# %%
+n_events = 10_000
+
+for _ in range(n_events):
+    if not pythia.next():
+        continue
+    n_charged = sum(
+        1 for p in pythia.event if p.isFinal() and p.isHadron() and p.isCharged()
+    )
+
+    multiparton_hist.fill(n_charged)
+
+# %% [markdown]
+# Visualize
+
+# %%
+y, yerr = multiparton_hist.get()
+
+fig, ax = plt.subplots()
+
+ax.errorbar(
+    bins[:-1],
+    y,
+    xerr=[w / 2.0 for w in multiparton_hist.widths],
+    yerr=yerr,
+    drawstyle="steps-mid",
+    fmt="-",
+    color="black",
+)
+
+ax.set_xlabel(r"$dN_{ch}/d\eta$")
+ax.set_ylabel(r"$P(dN_{ch}/d\eta)$")
+
+file_extension = ["png", "pdf"]
+for ext in file_extension:
+    fig.savefig(f"pythia_docs_example.{ext}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.jupytext]
+# Always pair ipynb notebooks to py:percent files
+formats = ["ipynb", "py:percent"]
+notebook_metadata_filter = "all,-jupytext.text_representation.jupytext_version"


### PR DESCRIPTION
```
* Add example notebook from the PYTHIA docs in the form of the jupytext paired .py file.
  The .py file form is versioned for better version control while still being
  able to generate the notebook file from it.
* Add pyproject.toml with jupytext config.
* Add matplotlib, ipympl, and jupytext to environment in binder/Dockerfile.
* Add conversion from .py to notebook forms during repo2docker build of binder/Dockerfile.
```