### PR TITLE
docs: Add typical docker run options for interactive use

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,11 @@ docker run \
 or you can run interactively
 
 ```
-docker run --rm -it matthewfeickert/pythia-python:latest
+docker run \
+  --rm \
+  -ti \
+  --publish 8888:8888 \
+  --user $(id -u $USER):$(id -g $USER) \
+  --volume $PWD:/work \
+  matthewfeickert/pythia-python:pythia8.308
 ```


### PR DESCRIPTION
* Add interactive flags, publish to port 8888, run as non-root user, and bind mount cwd to /work.