### PR TITLE
fix: Use --chown option in COPY to avoid image bloat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       run: >-
         docker run --rm
         --user $(id --user $USER):$(id --group)
-        --volume $PWD:/work
+        --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt';
         wc main01_out_cpp.txt
@@ -37,7 +37,7 @@ jobs:
       run: >-
         docker run --rm
         --user $(id --user $USER):$(id --group)
-        --volume $PWD:/work
+        --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         "python tests/main01.py > main01_out_py.txt";
         wc main01_out_py.txt
@@ -45,7 +45,7 @@ jobs:
       run: >-
         docker run --rm
         --user $(id --user $USER):$(id --group)
-        --volume $PWD:/work
+        --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         'g++ tests/main42.cc -pthread -o tests/main42 $(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
         wc main42_out.hepmc
@@ -58,13 +58,13 @@ jobs:
       run: >-
         docker run --rm
         --user $(id --user $USER):$(id --group)
-        --volume $PWD:/work
+        --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         'g++ tests/test_FastJet.cc -o tests/test_FastJet $(fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'
     - name: Test FastJet Python
       run: >-
         docker run --rm
         --user $(id --user $USER):$(id --group)
-        --volume $PWD:/work
+        --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         "python tests/test_FastJet.py"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can either use the image as "`PYTHIA` as a service", as demoed here with the
 docker run \
   --rm \
   --user $(id -u $USER):$(id -g $USER) \
-  --volume $PWD:/work \
+  --volume $PWD:/home/docker/work \
   matthewfeickert/pythia-python:pythia8.308 \
   'python tests/main01.py > main01_out_py.txt'
 ```
@@ -46,7 +46,7 @@ or the original C++
 docker run \
   --rm \
   --user $(id -u $USER):$(id -g $USER) \
-  --volume $PWD:/work \
+  --volume $PWD:/home/docker/work \
   matthewfeickert/pythia-python:pythia8.308 \
   'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt'
 ```
@@ -59,6 +59,6 @@ docker run \
   -ti \
   --publish 8888:8888 \
   --user $(id -u $USER):$(id -g $USER) \
-  --volume $PWD:/work \
+  --volume $PWD:/home/docker/work \
   matthewfeickert/pythia-python:pythia8.308
 ```

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,5 +1,8 @@
 FROM matthewfeickert/pythia-python:pythia8.308
 
+SHELL [ "/bin/bash", "-c" ]
+ENV PATH=/usr/local/venv/bin:"${PATH}"
+
 # Remove existing non-root user "docker" with uid 1000
 # to avoid conflict with jovyan
 USER root
@@ -12,10 +15,12 @@ ENV NB_UID ${NB_UID}
 ENV HOME /home/${NB_USER}
 
 USER root
-RUN adduser --disabled-password \
-    --gecos "Default user" \
-    --uid ${NB_UID} \
-    ${NB_USER}
+RUN adduser \
+      --shell /bin/bash \
+      --gecos "Default user" \
+      --uid ${NB_UID} \
+      --disabled-password \
+      ${NB_USER}
 USER ${NB_USER}
 
 # FIXME: Downgrade jupyter-server to contend with:
@@ -35,8 +40,7 @@ RUN python -m pip --no-cache-dir install --upgrade \
 COPY . ${HOME}
 USER root
 RUN find "${HOME}/examples" -type f -iname "*.py" | xargs jupytext --to notebook && \
-    chown -R ${NB_UID} ${HOME} && \
-    chown -R ${NB_UID} /usr/local/venv
+    chown -R ${NB_UID} ${HOME}
 USER ${NB_USER}
 WORKDIR ${HOME}
 


### PR DESCRIPTION
```
* Avoid using chown or chmod of objects created in previous layers as this
  counts as new information and will create duplication and image bloat. To
  avoid this for the Python virtual environment use the --chown option for the
  COPY command.
* Update volume mounts in README
```