### PR TITLE
feat: Add HepMC3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
         --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         'g++ tests/test_FastJet.cc -o tests/test_FastJet $(fastjet-config --cxxflags --libs --plugins); ./tests/test_FastJet'
+
     - name: Test FastJet Python
       run: >-
         docker run --rm
@@ -68,3 +69,11 @@ jobs:
         --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         "python tests/test_FastJet.py"
+
+    - name: Test Python imports
+      run: >-
+        docker run --rm
+        --user $(id --user $USER):$(id --group)
+        --volume $PWD:/home/docker/work
+        matthewfeickert/pythia-python:test
+        "python -m pip install --upgrade pytest; pytest --verbose tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,6 @@ jobs:
     - name: Test Python imports
       run: >-
         docker run --rm
-        --user $(id --user $USER):$(id --group)
         --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
         "python -m pip install --upgrade pytest; pytest --verbose tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI/CD
 
 on:
   push:
+    branches:
+    - master
   pull_request:
+    branches:
+    - master
   schedule:
   - cron:  '1 0 * * 0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,13 @@ jobs:
         tag_with_sha: true
         tag_with_ref: true
         push: false
+
     - name: List Built Images
       run: docker images
+
+    - name: Display user id
+      run: id
+
     - name: Run test program in C++
       run: >-
         docker run --rm
@@ -37,6 +42,7 @@ jobs:
         matthewfeickert/pythia-python:test
         'g++ tests/main01.cc -pthread -o tests/main01 $(pythia8-config --cxxflags --ldflags); ./tests/main01 > main01_out_cpp.txt';
         wc main01_out_cpp.txt
+
     - name: Run test program in Python
       run: >-
         docker run --rm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,19 +41,22 @@ jobs:
         matthewfeickert/pythia-python:test
         "python tests/main01.py > main01_out_py.txt";
         wc main01_out_py.txt
-    - name: Test HepMC
+
+    - name: Test HepMC3
       run: >-
         docker run --rm
         --user $(id --user $USER):$(id --group)
         --volume $PWD:/home/docker/work
         matthewfeickert/pythia-python:test
-        'g++ tests/main42.cc -pthread -o tests/main42 $(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
-        wc main42_out.hepmc
+        'g++ tests/main300.cc -pthread -o tests/main300 $(pythia8-config --cxxflags --ldflags) -lHepMC3; ./tests/main300 --input main300.cmnd --hepmc_output main300.hepmc'
+        wc main300.hepmc
+
     - name: Test LHAPDF CLI
       run: >-
         docker run --rm
         matthewfeickert/pythia-python:test
         "lhapdf install CT10nlo"
+
     - name: Test FastJet
       run: >-
         docker run --rm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,pythia8.308,pythia8.308-hepmc2.06.11-fastjet3.4.0-python3.10
+        tags: latest,pythia8.308,pythia8.308-hepmc3.2.5-fastjet3.4.0-python3.10
     - name: Build and Publish to Registry with Release Tag
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v1
@@ -31,5 +31,5 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: matthewfeickert/pythia-python
         dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.308,pythia8.308-hepmc2.06.11-fastjet3.4.0-python3.10
+        tags: latest,latest-stable,pythia8.308,pythia8.308-hepmc3.2.5-fastjet3.4.0-python3.10
         tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,15 +32,16 @@ RUN apt-get -qq -y update && \
 ARG HEPMC_VERSION=3.2.5
 RUN mkdir /code && \
     cd /code && \
-    wget https://hepmc.web.cern.ch/hepmc/releases/HepMC3-${HEPMC_VERSION}.tgz && \
-    tar xvfz HepMC3-${HEPMC_VERSION}.tgz && \
-    mv HepMC3-${HEPMC_VERSION}.tgz src && \
+    wget https://hepmc.web.cern.ch/hepmc/releases/HepMC3-${HEPMC_VERSION}.tar.gz && \
+    tar xvfz HepMC3-${HEPMC_VERSION}.tar.gz && \
+    mv HepMC3-${HEPMC_VERSION} src && \
     cmake \
       -DCMAKE_CXX_COMPILER=$(command -v g++) \
       -DCMAKE_BUILD_TYPE=Release \
-      -Dbuild_docs:BOOL=OFF \
-      -Dmomentum:STRING=MEV \
-      -Dlength:STRING=MM \
+      -DHEPMC3_ENABLE_ROOTIO=OFF \
+      -DHEPMC3_ENABLE_PYTHON=ON \
+      -DHEPMC3_PYTHON_VERSIONS=3.X \
+      -DHEPMC3_ENABLE_TEST=ON \
       -DCMAKE_INSTALL_PREFIX=/usr/local/venv \
       -S src \
       -B build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ RUN apt-get -qq -y update && \
 ARG HEPMC_VERSION=3.2.5
 RUN mkdir /code && \
     cd /code && \
-    wget http://hepmc.web.cern.ch/hepmc/releases/hepmc${HEPMC_VERSION}.tgz && \
-    tar xvfz hepmc${HEPMC_VERSION}.tgz && \
-    mv HepMC-${HEPMC_VERSION} src && \
+    wget https://hepmc.web.cern.ch/hepmc/releases/HepMC3-${HEPMC_VERSION}.tgz && \
+    tar xvfz HepMC3-${HEPMC_VERSION}.tgz && \
+    mv HepMC3-${HEPMC_VERSION}.tgz src && \
     cmake \
       -DCMAKE_CXX_COMPILER=$(command -v g++) \
       -DCMAKE_BUILD_TYPE=Release \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get -qq -y update && \
     python -m pip list
 
 # Install HepMC
-ARG HEPMC_VERSION=2.06.11
+ARG HEPMC_VERSION=3.2.5
 RUN mkdir /code && \
     cd /code && \
     wget http://hepmc.web.cern.ch/hepmc/releases/hepmc${HEPMC_VERSION}.tgz && \
@@ -99,7 +99,7 @@ RUN mkdir /code && \
       --cxx=g++ \
       --enable-64bit \
       --with-gzip \
-      --with-hepmc2=/usr/local/venv \
+      --with-hepmc3=/usr/local/venv \
       --with-lhapdf6=/usr/local/venv \
       --with-fastjet3=/usr/local/venv \
       --with-python-bin=/usr/local/venv/bin/ \

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,13 @@ test:
 		"python tests/main01.py > main01_out_py.txt"
 	wc main01_out_py.txt
 
-test_hepmc:
+test_hepmc3:
 	docker run \
 		--rm \
 		--user $(shell id --user $(USER)):$(shell id --group) \
 		--volume $(shell pwd):/work \
 		matthewfeickert/pythia-python:latest \
-		'g++ tests/main42.cc -pthread -o tests/main42 $$(pythia8-config --cxxflags --ldflags) -lHepMC; ./tests/main42 tests/main42.cmnd main42_out.hepmc'
+		'g++ tests/main300.cc -pthread -o tests/main300 $$(pythia8-config --cxxflags --ldflags) -lHepMC3; ./tests/main300 --input main300.cmnd --hepmc_output main300.hepmc'
 
 test_fastjet:
 	docker run \

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ image:
 	docker build . \
 	-f Dockerfile \
 	--build-arg BASE_IMAGE=python:3.10-slim-bullseye \
-	--build-arg HEPMC_VERSION=2.06.11 \
+	--build-arg HEPMC_VERSION=3.2.5 \
 	--build-arg LHAPDF_VERSION=6.5.3 \
 	--build-arg FASTJET_VERSION=3.4.0 \
 	--build-arg PYTHIA_VERSION=8308 \
 	--tag matthewfeickert/pythia-python:pythia8.308 \
-	--tag matthewfeickert/pythia-python:pythia8.308-hepmc2.06.11-fastjet3.4.0-python3.10 \
+	--tag matthewfeickert/pythia-python:pythia8.308-hepmc3.2.5-fastjet3.4.0-python3.10 \
 	--tag matthewfeickert/pythia-python:latest
 
 run:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 The Docker image contains:
 
 * Python 3.10
-* [HepMC2](http://hepmc.web.cern.ch/hepmc/) `v2.06.11`
+* [HepMC3](http://hepmc.web.cern.ch/hepmc/) `v3.2.5`
 * [LHAPDF](https://lhapdf.hepforge.org/) `v6.5.3`
 * [FastJet](http://fastjet.fr/) `v3.4.0`
 * [PYTHIA](https://pythia.org/) `v8.308`

--- a/tests/main300.cc
+++ b/tests/main300.cc
@@ -1,0 +1,862 @@
+// main300.cc is a part of the PYTHIA event generator.
+// Copyright (C) 2022 Torbjorn Sjostrand.
+// PYTHIA is licenced under the GNU GPL v2 or later, see COPYING for details.
+// Please respect the MCnet Guidelines, see GUIDELINES for details.
+
+// The following functions analyze a scattering event and save the event in
+// an output format that can be converted into a postscript figure using the
+// "graphviz" program.
+
+// Authors: Nadine Fischer
+
+// Keywords: Dire; Vincia; hepmc; OpenMP; command file; command line option
+
+// Pythia includes.
+#include "Pythia8/Pythia.h"
+#ifdef HEPMC3
+#include "Pythia8Plugins/HepMC3.h"
+#endif
+
+// OpenMP includes.
+#ifdef OPENMP
+#include <omp.h>
+#endif
+
+// Include graphviz visualisation plugin.
+#include "Pythia8Plugins/Visualisation.h"
+
+using namespace Pythia8;
+
+//==========================================================================
+
+void printHelp() {
+  cout << "\n"
+    << "Simple standardized executable for the Pythia+Dire event "
+    << "generator.\n\n"
+    << "Usage:\n\n"
+    << "main300 [option] <optionValue> [option] <optionValue> ...\n\n"
+    << "Examples:\n\n"
+    << "main300 --nevents 50 --setting \"WeakSingleBoson:ffbar2gmZ = on\"\n"
+    << "main300 --input main300.cmnd --hepmc_output myfile.hepmc\n\n"
+    << "Options:\n\n"
+    << "  --visualize_event       :"
+    << " Saves one event for visualization of event generation steps.\n"
+    << "  --nevents N             :"
+    << " Generate N events (overwrites default value and\n"
+    << "                           "
+    << " number of events in input settings file).\n"
+    << "  --nthreads N            :"
+    << " Use N threads, takes effect only if Dire was configured\n"
+    << "                            with OpenMP\n"
+    << "  --input FILENAME        :"
+    << " Use file FILENAME to read & use Pythia settings.\n"
+    << "                            Multiple input files are allowed.\n"
+    << "  --hepmc_output FILENAME :"
+    << " Store generated events in HepMC file FILENAME.\n"
+    << "  --lhef_output FILENAME :"
+    << " Store generated events in LHEF  file FILENAME.\n"
+    << "  --setting VALUE         :"
+    << " Use the Pythia/Dire setting VALUE for event generation, e.g.\n"
+    << "                            --setting Beams:eCM=100.0\n"
+    << "                            --setting \"Beams:idA = -11\"\n"
+    << "                            --setting \"PartonLevel:MPI = off\"\n"
+    << "                           "
+    << " possible Pythia/Dire settings can be found in the\n"
+    << "                            respective online manuals\n\n"
+    << endl;
+}
+
+//--------------------------------------------------------------------------
+
+int main( int argc, char* argv[] ){
+
+  // Get command-line arguments
+  vector<string> arguments;
+  for (int i = 0; i < argc; ++i) {
+    arguments.push_back(string(argv[i]));
+    if (arguments.back() == "--visualize_event")
+      arguments.push_back(" ");
+  }
+
+  // Print help.
+  if ( find(arguments.begin(), arguments.end(), "--help") != arguments.end()
+    || find(arguments.begin(), arguments.end(), "-h")     != arguments.end()
+    || arguments.size()<2) {
+    printHelp();
+    return 0;
+  }
+
+  // Parse command-line arguments
+  // Input file.
+  vector<string>::iterator it
+     = std::find(arguments.begin(),arguments.end(),"--input");
+  string input  = (it != arguments.end()) ? *(it+1) : "";
+  // Output hepmc file.
+  it = std::find(arguments.begin(),arguments.end(),"--hepmc_output");
+  string hepmc_output = (it != arguments.end()) ? *(it+1) : "";
+  // Output lhe file.
+  it = std::find(arguments.begin(),arguments.end(),"--lhef_output");
+  string lhef_output = (it != arguments.end()) ? *(it+1) : "";
+  // Number of events to generate.
+  it = std::find(arguments.begin(),arguments.end(),"--nevents");
+  int nevents = (it != arguments.end()) ? atoi((*(it+1)).c_str()) : -1;
+#ifdef OPENMP
+  // Number of threads.
+  it = std::find(arguments.begin(),arguments.end(),"--nthreads");
+  int nThreads = (it != arguments.end()) ? atoi((*(it+1)).c_str()) : 1;
+#endif
+  // The visualize_event flag,
+  it = std::find(arguments.begin(),arguments.end(),"--visualize_event");
+  bool visualize_event     = (it != arguments.end());
+  string visualize_output  = (input == "") ? "event" : "event-" + input;
+  replace(visualize_output.begin(), visualize_output.end(), '/', '-');
+
+  vector<Pythia*> pythiaPtr;
+
+  // Read input files.
+  vector<string> input_file;
+  int countInput(0);
+  for (int i = 0; i < int(arguments.size()); ++i)
+    if (arguments[i] == "--input" && i+1 <= int(arguments.size())-1) {
+      input_file.push_back(arguments[i+1]);
+      countInput++;
+    }
+  if (input_file.size() < 1) input_file.push_back("");
+
+  // For several settings files as input, check that they use
+  // a different process.
+  if (input_file.size() > 1) {
+    bool sameProcess = false;
+    for (int i = 1; i < int(input_file.size()); ++i)
+      if (input_file[i] == input_file[i-1]) sameProcess = true;
+    if (sameProcess)
+      cout << "WARNING: several input files with the same name\n"
+        << " found; this will lead to a wrong cross section!\n";
+  }
+
+  std::streambuf *old = cout.rdbuf();
+  stringstream ss;
+  for (int i = 0; i < int(input_file.size()); ++i) {
+    ss.str("");
+    // Redirect output so that Pythia banner will not be printed twice.
+    if(i>0) cout.rdbuf (ss.rdbuf());
+    pythiaPtr.push_back( new Pythia());
+    // Restore print-out.
+    cout.rdbuf (old);
+  }
+
+#ifdef OPENMP
+  old = cout.rdbuf();
+  int nThreadsMax = omp_get_max_threads();
+  int nThreadsReq = min(nThreads,nThreadsMax);
+  // Divide a single Pythia object into several, in case of multiple threads.
+  int nPythiaOrg = (int)pythiaPtr.size();
+
+  if (nThreadsReq > 1 && (nPythiaOrg == 1 || nThreadsReq%nPythiaOrg ==0)) {
+    int niterations(0);
+    for (int i = nPythiaOrg; i < nThreadsReq; ++i) {
+      if (i%nPythiaOrg == 0) niterations++;
+      int ifile    = i-niterations*nPythiaOrg;
+      string sfile = input_file[ifile];
+      input_file.push_back(sfile);
+      ss.str("");
+      // Redirect output so that Pythia banner will not be printed twice.
+      cout.rdbuf (ss.rdbuf());
+      pythiaPtr.push_back( new Pythia());
+    }
+  }
+
+  // Restore print-out.
+  cout.rdbuf (old);
+
+  bool doParallel = true;
+  int  nPythiaAct = (int)pythiaPtr.size();
+  // The number of Pythia objects exceeds the number of available threads.
+  if (nPythiaAct > nThreadsReq) {
+    cout << "WARNING: The number of requested Pythia instances exceeds the\n"
+      << " number of available threads! No parallelization will be done!\n";
+    nThreadsReq = 1;
+    doParallel  = false;
+  } else if (nPythiaAct == 1) {
+    cout << "WARNING: The number of requested Pythia instances still one!\n"
+      << " No parallelization will be done!\n";
+    nThreadsReq = 1;
+    doParallel  = false;
+  } else if (nPythiaAct < nThreadsReq) {
+    cout << "WARNING: The number of requested Pythia instances too small!\n"
+      << " Reset to minimal parallelization!\n";
+    nThreadsReq = nPythiaAct;
+  }
+
+  // Only print with first Pythia instance to avoid output mangling.
+  if (doParallel) for (int j = 1; j < int(pythiaPtr.size()); ++j)
+    pythiaPtr[j]->readString("Print:quiet = on");
+
+#endif
+
+  // Force PhaseSpace:pTHatMinDiverge to something very small to not bias DIS.
+  for (int i = 0; i < int(pythiaPtr.size()); ++i)
+    pythiaPtr[i]->settings.forceParm("PhaseSpace:pTHatMinDiverge",5e-2);
+  // Print warning that the parameter has been reset, some general guidelines,
+  // and then wait for a few seconds, so that users can read the comments.
+  cout
+    << "\nINFORMATION:\n"
+    << "   Forcing PhaseSpace:pTHatMinDiverge to very small\n"
+    << "   value 0.05 GeV to prevent aggressive phase-space\n"
+    << "   restriction of deep-inelastic scattering configurations.\n"
+    << "   Default minimum value of 0.5 GeV may be reinstated from command\n"
+    << "   line or input file settings.\n"
+    << "\nNOTE THAT\n"
+    << "   2->2 processes in pp collisions require setting "
+    <<     "PhaseSpace:pTHatMin\n"
+    << "   2->2 processes in DIS collisions require setting "
+    <<     "PhaseSpace:Q2min\n"
+    << "   (see details in the ''Phase Space Cuts'' section of the online "
+    <<     "manual)" << endl;
+
+  // Read command line settings.
+  int countSettings(0);
+  for (int i = 0; i < int(arguments.size()); ++i) {
+    if (arguments[i] == "--setting" && i+1 <= int(arguments.size())-1) {
+      string setting = arguments[i+1];
+      replace(setting.begin(), setting.end(), '"', ' ');
+
+      // Skip Dire settings at this stage.
+      if (setting.find("Dire") != string::npos) continue;
+      if (setting.find("Enhance") != string::npos) continue;
+
+      for (int j = 0; j < int(pythiaPtr.size()); ++j) {
+        pythiaPtr[j]->readString(setting);
+        countSettings++;
+      }
+
+    }
+  }
+
+  // Read command line settings again and overwrite file settings.
+  for (int i = 0; i < int(arguments.size()); ++i) {
+    if (arguments[i] == "--setting" && i+1 <= int(arguments.size())-1) {
+      string setting = arguments[i+1];
+      replace(setting.begin(), setting.end(), '"', ' ');
+      for (int j = 0; j < int(pythiaPtr.size()); ++j)
+        pythiaPtr[j]->readString(setting);
+    }
+  }
+
+  if( countInput == 0 && countSettings == 0 ) {
+    cout << "Error:  no runtime parameters have been passed to Pythia" ;
+    cout << " using --input or --setting.  Run with --help for options."
+         << endl;
+    return 1;
+  }
+
+  for (int i = 0; i < int(pythiaPtr.size()); ++i)
+    if (i < int(input_file.size()) && input_file[i] != "")
+      pythiaPtr[i]->readFile(input_file[i].c_str());
+
+  // Two classes to do the two PDFs externally. Hand pointers to Pythia.
+  PDFPtr pdfAPtr = nullptr;
+  PDFPtr pdfBPtr = nullptr;
+
+  // Allow Pythia to use Dire merging classes.
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    if (pdfAPtr != nullptr) pythiaPtr[i]->setPDFAPtr(pdfAPtr);
+    if (pdfBPtr != nullptr) pythiaPtr[i]->setPDFBPtr(pdfBPtr);
+  }
+
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    if (i < int(input_file.size()) && input_file[i] != "")
+      pythiaPtr[i]->readFile(input_file[i].c_str());
+    pythiaPtr[i]->init();
+  }
+
+#ifdef OPENMP
+  // A divided single Pythia run does not work with Les Houches events.
+  if (nThreadsReq > 1 && nPythiaOrg == 1 &&
+    pythiaPtr.front()->mode("Beams:frameType") > 3) {
+    cout << "WARNING: can not divide the run into subruns as the\n"
+      << " same hard events from the Les Houches file would be\n"
+      << " used multiple times!\n";
+    // Clean-up.
+    nThreadsReq = 1;
+    for (int i = 1; i < int(pythiaPtr.size()); ++i) {
+      delete pythiaPtr[i]; pythiaPtr[i]=0;
+    }
+  }
+  // Add random seeds for parallelization of a single Pythia run.
+  bool splitSingleRun = false;
+  if (nThreadsReq > 1 && nPythiaOrg == 1) {
+    splitSingleRun = true;
+    int randomOffset = 100;
+    for (int j = 0; j < int(pythiaPtr.size()); ++j) {
+      pythiaPtr[j]->readString("Random:setSeed = on");
+      pythiaPtr[j]->readString("Random:seed = " +
+                               std::to_string(randomOffset + j));
+    }
+  }
+#endif
+
+  int nEventEst = pythiaPtr.front()->settings.mode("Main:numberOfEvents");
+  if (nevents > 0) nEventEst = nevents;
+
+  int nEventEstEach = nEventEst;
+#ifdef OPENMP
+  // Number of events per thread.
+  if (nThreadsReq > 1) {
+    while (nEventEst%nThreadsReq != 0) nEventEst++;
+    nEventEstEach = nEventEst/nThreadsReq;
+  }
+#endif
+
+  // Switch off all showering and MPI when estimating the cross section,
+  // and re-initialise (unfortunately).
+  bool fsr = pythiaPtr.front()->flag("PartonLevel:FSR");
+  bool isr = pythiaPtr.front()->flag("PartonLevel:ISR");
+  bool mpi = pythiaPtr.front()->flag("PartonLevel:MPI");
+  bool had = pythiaPtr.front()->flag("HadronLevel:all");
+  bool rem = pythiaPtr.front()->flag("PartonLevel:Remnants");
+  bool chk = pythiaPtr.front()->flag("Check:Event");
+  vector<bool> merge;
+  if (!visualize_event) {
+    for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+      bool doMerge = pythiaPtr[i]->flag("Merging:doMerging");
+      merge.push_back(doMerge);
+      pythiaPtr[i]->settings.flag("PartonLevel:FSR",false);
+      pythiaPtr[i]->settings.flag("PartonLevel:ISR",false);
+      pythiaPtr[i]->settings.flag("PartonLevel:MPI",false);
+      pythiaPtr[i]->settings.flag("HadronLevel:all",false);
+      pythiaPtr[i]->settings.flag("PartonLevel:Remnants",false);
+      pythiaPtr[i]->settings.flag("Check:Event",false);
+      if (doMerge) pythiaPtr[i]->settings.flag
+                     ("Merging:doXSectionEstimate", true);
+    }
+  }
+
+  for (int i = 0; i < int(pythiaPtr.size()); ++i)
+    pythiaPtr[i]->init();
+
+  // Cross section estimate run.
+  vector<double> nash, sumsh;
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    nash.push_back(0.);
+    sumsh.push_back(0.);
+  }
+
+  // Save a single event for event generation visualization.
+  if (visualize_event) {
+    while ( !pythiaPtr.front()->next() )
+      if ( pythiaPtr.front()->info.atEndOfFile() ) break;
+    printEvent(pythiaPtr.front()->event, visualize_output);
+    cout << "\nCreated event visualization. Exiting event generation.\n"<<endl;
+    // Clean-up.
+    for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+      delete pythiaPtr[i]; pythiaPtr[i]=0;
+    }
+    return 0;
+  }
+
+#ifdef OPENMP
+#pragma omp parallel num_threads(nThreadsReq)
+{
+  for (int i = 0; i < nEventEstEach; ++i) {
+    vector<int> pythiaIDs;
+    // If parallelization can not be done, loop through all
+    // Pythia objects.
+    if (!doParallel)
+      for (int j = 0; j < int(pythiaPtr.size()); ++j)
+        pythiaIDs.push_back(j);
+    else pythiaIDs.push_back(omp_get_thread_num());
+    for (int id = 0; id < int(pythiaIDs.size()); ++id) {
+      int j = pythiaIDs[id];
+      if ( !pythiaPtr[j]->next() ) {
+        if ( pythiaPtr[j]->info.atEndOfFile() ) break;
+        else continue;
+      }
+      sumsh[j] += pythiaPtr[j]->info.weight();
+      map <string,string> eventAttributes;
+      if (pythiaPtr[j]->info.eventAttributes)
+        eventAttributes = *(pythiaPtr[j]->info.eventAttributes);
+      string trials = (eventAttributes.find("trials") != eventAttributes.end())
+                    ?  eventAttributes["trials"] : "";
+      if (trials != "") nash[j] += atof(trials.c_str());
+    }
+  }
+}
+#pragma omp barrier
+#else
+
+  for (int i = 0; i < nEventEstEach; ++i) {
+    for (int j = 0; j < int(pythiaPtr.size()); ++j) {
+      if ( !pythiaPtr[j]->next() ) {
+        if ( pythiaPtr[j]->info.atEndOfFile() ) break;
+        else continue;
+      }
+      sumsh[j] += pythiaPtr[j]->info.weight();
+      map <string,string> eventAttributes;
+      if (pythiaPtr[j]->info.eventAttributes)
+        eventAttributes = *(pythiaPtr[j]->info.eventAttributes);
+      string trials = (eventAttributes.find("trials") != eventAttributes.end())
+                    ?  eventAttributes["trials"] : "";
+      if (trials != "") nash[j] += atof(trials.c_str());
+    }
+  }
+#endif
+
+  // Store estimated cross sections.
+  vector<double> na, xss;
+  old = cout.rdbuf();
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    // Redirect output so that Pythia banner will not be printed twice.
+    ss.str("");
+    cout.rdbuf (ss.rdbuf());
+    pythiaPtr[i]->stat();
+    na.push_back(pythiaPtr[i]->info.nAccepted());
+    xss.push_back(pythiaPtr[i]->info.sigmaGen());
+  }
+  // Restore print-out.
+  cout.rdbuf (old);
+
+#ifdef HEPMC3
+  bool printHepMC = !(hepmc_output == "");
+  // Interface for conversion from Pythia8::Event to HepMC one.
+  HepMC3::Pythia8ToHepMC3 toHepMC;
+  // Specify file where HepMC events will be stored.
+  HepMC3::WriterAscii ascii_io(hepmc_output);
+  // Switch off warnings for parton-level events.
+  toHepMC.set_print_inconsistency(false);
+  toHepMC.set_free_parton_warnings(false);
+  // Do not store cross section information, as this will be done manually.
+  toHepMC.set_store_pdf(false);
+  toHepMC.set_store_proc(false);
+  toHepMC.set_store_xsec(false);
+  vector< HepMC3::WriterAscii* > ascii_io_var;
+#endif
+
+  // Cross section and weights:
+  // Total for all runs combined: main.
+  double sigmaTotAll(0.);
+  // Total for all runs combined: variations.
+  vector<double> sigmaTotVarAll;
+  // Individual run: main.
+  vector<double> sigmaInc, sigmaTot, sumwt, sumwtsq;
+  // Individual run: variations.
+  vector<vector<double> > sigmaTotVar;
+  // Check variations.
+  bool doVariationsAll(true);
+  for (int i = 0; i < int(pythiaPtr.size()); ++i)
+    if ( ! pythiaPtr.front()->settings.flag("Variations:doVariations") )
+      doVariationsAll = false;
+  if ( doVariationsAll ) {
+    for (int iwt=0; iwt < 3; ++iwt) {
+#ifdef HEPMC3
+      if (printHepMC) {
+        string hepmc_var = hepmc_output + "-" + std::to_string(iwt);
+        ascii_io_var.push_back(new HepMC3::WriterAscii(hepmc_var));
+      }
+#endif
+      sigmaTotVarAll.push_back(0.);
+    }
+  }
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    sigmaTotVar.push_back(vector<double>());
+    if ( doVariationsAll ) {
+      for (int iwt=0; iwt < 3; ++iwt)
+        sigmaTotVar.back().push_back(0.);
+    }
+    sigmaInc.push_back(0.);
+    sigmaTot.push_back(0.);
+    sumwt.push_back(0.);
+    sumwtsq.push_back(0.);
+  }
+
+  int nEvent = pythiaPtr.front()->settings.mode("Main:numberOfEvents");
+  if (nevents > 0) nEvent = nevents;
+
+  int nEventEach = nEvent;
+#ifdef OPENMP
+  // Number of events per thread.
+  if (nThreadsReq > 1) {
+    while (nEvent%nThreadsReq != 0) nEvent++;
+    nEventEach = nEvent/nThreadsReq;
+  }
+#endif
+
+  // Histogram of the event weight.
+  Hist weight_histogram("weight",10000,-100.,100.);
+  Hist pos_weight_histogram("weight",100,0.,100.);
+  Hist neg_weight_histogram("weight",100,0.,100.);
+
+  cout << endl << endl << endl;
+  cout << "Start generating events" << endl;
+
+  // Switch showering and multiple interaction back on.
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    pythiaPtr[i]->settings.flag("PartonLevel:FSR",fsr);
+    pythiaPtr[i]->settings.flag("PartonLevel:ISR",isr);
+    pythiaPtr[i]->settings.flag("HadronLevel:all",had);
+    pythiaPtr[i]->settings.flag("PartonLevel:MPI",mpi);
+    pythiaPtr[i]->settings.flag("PartonLevel:Remnants",rem);
+    pythiaPtr[i]->settings.flag("Check:Event",chk);
+    pythiaPtr[i]->settings.flag("Merging:doMerging",merge[i]);
+    pythiaPtr[i]->settings.flag("Merging:doXSectionEstimate", false);
+  }
+
+  // Reinitialize Pythia for event generation runs.
+  for (int i = 0; i < int(pythiaPtr.size()); ++i)
+    pythiaPtr[i]->init();
+
+  // Event generation run.
+
+#ifdef OPENMP
+#pragma omp parallel num_threads(nThreadsReq)
+{
+  for (int i = 0; i < nEventEach; ++i) {
+
+    vector<int> pythiaIDs;
+    // If parallelization can not be done, loop through all
+    // Pythia objects.
+    if (!doParallel)
+      for (int j = 0; j < int(pythiaPtr.size()); ++j)
+        pythiaIDs.push_back(j);
+    else pythiaIDs.push_back(omp_get_thread_num());
+    for (int id = 0; id < int(pythiaIDs.size()); ++id) {
+      int j = pythiaIDs[id];
+      if ( !pythiaPtr[j]->next() ) {
+        if ( pythiaPtr[j]->info.atEndOfFile() ) break;
+        else continue;
+      }
+
+      // Do MEM.
+      if (pythiaPtr[j]->settings.flag("Dire:doMEM")) { ; }
+
+      // Get event weight(s).
+      double evtweight = pythiaPtr[j]->info.weight();
+
+      // Do not print zero-weight events.
+      if ( evtweight == 0. ) continue;
+
+#pragma omp critical
+{
+      weight_histogram.fill( evtweight, 1.0);
+      if (evtweight>0.) pos_weight_histogram.fill( evtweight, 1.0);
+      if (evtweight<0.) neg_weight_histogram.fill(-evtweight, 1.0);
+      if (i>0 && i%1000==0) {
+        ofstream wr;
+        wr.open("weights.dat");
+        weight_histogram /= double(i);
+        weight_histogram.table(wr);
+        weight_histogram *= double(i);
+        wr.close();
+        wr.open("pos_weights.dat");
+        pos_weight_histogram /= double(i);
+        pos_weight_histogram.table(wr);
+        pos_weight_histogram *= double(i);
+        wr.close();
+        wr.open("neg_weights.dat");
+        neg_weight_histogram /= double(i);
+        neg_weight_histogram.table(wr);
+        neg_weight_histogram *= double(i);
+        wr.close();
+      }
+}
+
+      if (abs(evtweight) > 1e3) {
+#pragma omp critical
+{
+        cout << scientific << setprecision(8)
+             << "Warning in main program main300.cc: Large shower weight wt="
+             << evtweight << endl;
+        if (abs(evtweight) > 1e4) {
+          cout << "Warning in main program main300.cc: Shower weight larger"
+               << " than 10000. Discard event with rare shower weight"
+               << " fluctuation." << endl;
+          evtweight = 0.;
+        }
+}
+      }
+
+      // Do not print zero-weight events.
+      if ( evtweight == 0. ) continue;
+
+      // Now retrieve additional shower weights, and combine these
+      // into muR-up and muR-down variations.
+      vector<double> evtweights;
+
+#pragma omp critical
+{
+
+      sumwt[j]   += evtweight;
+      sumwtsq[j] += pow2(evtweight);
+
+      double normhepmc = xss[j]/na[j];
+
+      // Weighted events with additional number of trial events to consider.
+      if ( pythiaPtr[j]->info.lhaStrategy() != 0
+        && pythiaPtr[j]->info.lhaStrategy() != 3
+        && nash[j] > 0)
+        normhepmc = 1. / (1e9*nash[j]);
+      // Weighted events.
+      else if ( pythiaPtr[j]->info.lhaStrategy() != 0
+        && pythiaPtr[j]->info.lhaStrategy() != 3
+        && nash[j] == 0)
+        normhepmc = 1. / (1e9*na[j]);
+
+      if (pythiaPtr[j]->settings.flag("PhaseSpace:bias2Selection"))
+        normhepmc = xss[j] / (sumsh[j]);
+
+      if (pythiaPtr[j]->event.size() > 3) {
+
+        double w = evtweight*normhepmc;
+        // Add the weight of the current event to the cross section.
+        double divide = (splitSingleRun ? double(nThreadsReq) : 1.0);
+        sigmaTotAll += w/divide;
+        sigmaInc[j] += evtweight*normhepmc;
+        sigmaTot[j] += w;
+#ifdef HEPMC3
+        if (printHepMC) {
+          // Construct new empty HepMC event.
+          HepMC3::GenEvent hepmcevt;
+          // Set event weight
+          hepmcevt.weights().push_back(w);
+          // Fill HepMC event
+          toHepMC.fill_next_event( *pythiaPtr[j], &hepmcevt );
+          // Report cross section to hepmc.
+          shared_ptr<HepMC3::GenCrossSection> xsec;
+          xsec = make_shared<HepMC3::GenCrossSection>();
+          // First add object to event, then set cross section. This
+          // order ensures that the lengths of the cross section and
+          // the weight vector agree.
+          hepmcevt.set_cross_section( xsec );
+          xsec->set_cross_section( sigmaTotAll*1e9,
+            pythiaPtr[j]->info.sigmaErr()*1e9 );
+          // Write the HepMC event to file. Done with it.
+          ascii_io.write_event(hepmcevt);
+        }
+#endif
+
+        // Write additional HepMC events.
+        for (int iwt=0; iwt < int(evtweights.size()); ++iwt) {
+          double wVar = evtweight*evtweights[iwt]*normhepmc;
+          // Add the weight of the current event to the cross section.
+          double divideVar = (splitSingleRun ? double(nThreadsReq) : 1.0);
+          sigmaTotVarAll[iwt] += wVar/divideVar;
+          sigmaTotVar[j][iwt] += wVar;
+#ifdef HEPMC3
+          if (printHepMC) {
+            HepMC3::GenEvent hepmcevt;
+            // Set event weight
+            hepmcevt.weights().push_back(wVar);
+            // Fill HepMC event
+            toHepMC.fill_next_event( *pythiaPtr[j], &hepmcevt );
+            // Report cross section to hepmc.
+            shared_ptr<HepMC3::GenCrossSection> xsec;
+            xsec = make_shared<HepMC3::GenCrossSection>();
+            // First add object to event, then set cross section. This
+            // order ensures that the lengths of the cross section and
+            // the weight vector agree.
+            hepmcevt.set_cross_section( xsec );
+            xsec->set_cross_section( sigmaTotVarAll[iwt]*1e9,
+              pythiaPtr[j]->info.sigmaErr()*1e9 );
+            // Write the HepMC event to file. Done with it.
+            ascii_io_var[iwt]->write_event(hepmcevt);
+          }
+#endif
+        }
+      }
+    }
+  }
+}
+}
+#pragma omp barrier
+#else
+  for (int i = 0; i < nEventEach; ++i) {
+
+    for (int j = 0; j < int(pythiaPtr.size()); ++j) {
+      if ( !pythiaPtr[j]->next() ) {
+        if ( pythiaPtr[j]->info.atEndOfFile() ) break;
+        else continue;
+      }
+
+      // Get event weight(s).
+      double evtweight = pythiaPtr[j]->info.weight();
+
+      // Do not print zero-weight events.
+      if ( evtweight == 0. ) continue;
+
+      weight_histogram.fill( evtweight, 1.0);
+      if (evtweight>0.) pos_weight_histogram.fill( evtweight, 1.0);
+      if (evtweight<0.) neg_weight_histogram.fill(-evtweight, 1.0);
+      if (i>0 && i%1000==0) {
+        ofstream wr;
+        wr.open("weights.dat");
+        weight_histogram /= double(i);
+        weight_histogram.table(wr);
+        weight_histogram *= double(i);
+        wr.close();
+        wr.open("pos_weights.dat");
+        pos_weight_histogram /= double(i);
+        pos_weight_histogram.table(wr);
+        pos_weight_histogram *= double(i);
+        wr.close();
+        wr.open("neg_weights.dat");
+        neg_weight_histogram /= double(i);
+        neg_weight_histogram.table(wr);
+        neg_weight_histogram *= double(i);
+        wr.close();
+      }
+
+      if (abs(evtweight) > 1e3) {
+        cout << scientific << setprecision(8)
+          << "Warning in main program main300.cc: Large shower weight wt="
+          << evtweight << endl;
+        if (abs(evtweight) > 1e4) {
+          cout << "Warning in main program main300.cc: Shower weight larger"
+               << " than 10000. Discard event with rare shower weight"
+               << " fluctuation." << endl;
+          evtweight = 0.;
+        }
+      }
+
+      // Do not print zero-weight events.
+      if ( evtweight == 0. ) continue;
+
+      // Now retrieve additional shower weights, and combine these
+      // into muR-up and muR-down variations.
+      vector<double> evtweights;
+      sumwt[j]   += evtweight;
+      sumwtsq[j] += pow2(evtweight);
+      double normhepmc = xss[j]/na[j];
+
+      // Weighted events with additional number of trial events to consider.
+      if ( pythiaPtr[j]->info.lhaStrategy() != 0
+        && pythiaPtr[j]->info.lhaStrategy() != 3
+        && nash[j] > 0)
+        normhepmc = 1. / (1e9*nash[j]);
+      // Weighted events.
+      else if ( pythiaPtr[j]->info.lhaStrategy() != 0
+        && pythiaPtr[j]->info.lhaStrategy() != 3
+        && nash[j] == 0)
+        normhepmc = 1. / (1e9*na[j]);
+
+      if (pythiaPtr[j]->settings.flag("PhaseSpace:bias2Selection"))
+        normhepmc = 1. / (1e9*na[j]);
+
+      if (pythiaPtr[j]->event.size() > 3) {
+
+        double w = evtweight*normhepmc;
+        // Add the weight of the current event to the cross section.
+        sigmaTotAll += w;
+        sigmaInc[j] += evtweight*normhepmc;
+        sigmaTot[j] += w;
+#ifdef HEPMC3
+        if (printHepMC) {
+          // Construct new empty HepMC event.
+          HepMC3::GenEvent hepmcevt;
+          // Set event weight
+          hepmcevt.weights().push_back(w);
+          // Fill HepMC event
+          toHepMC.fill_next_event( *pythiaPtr[j], &hepmcevt );
+          // Report cross section to hepmc.
+          shared_ptr<HepMC3::GenCrossSection> xsec;
+          xsec = make_shared<HepMC3::GenCrossSection>();
+          // First add object to event, then set cross section. This
+          // order ensures that the lengths of the cross section and
+          // the weight vector agree.
+          hepmcevt.set_cross_section( xsec );
+          xsec->set_cross_section( sigmaTotAll*1e9,
+            pythiaPtr[j]->info.sigmaErr()*1e9 );
+          // Write the HepMC event to file.
+          ascii_io.write_event(hepmcevt);
+        }
+#endif
+
+        // Write additional HepMC events.
+        for (int iwt=0; iwt < int(evtweights.size()); ++iwt) {
+          double wVar = evtweight*evtweights[iwt]*normhepmc;
+          // Add the weight of the current event to the cross section.
+          sigmaTotVarAll[iwt] += wVar;
+          sigmaTotVar[j][iwt] += wVar;
+#ifdef HEPMC3
+          if (printHepMC) {
+            HepMC3::GenEvent hepmcevt;
+            // Set event weight
+            hepmcevt.weights().push_back(wVar);
+            // Fill HepMC event
+            toHepMC.fill_next_event( *pythiaPtr[j], &hepmcevt );
+            // Report cross section to hepmc.
+            shared_ptr<HepMC3::GenCrossSection> xsec;
+            xsec = make_shared<HepMC3::GenCrossSection>();
+            // First add object to event, then set cross section. This
+            // order ensures that the lengths of the cross section and
+            // the weight vector agree.
+            hepmcevt.set_cross_section( xsec );
+            xsec->set_cross_section( sigmaTotVarAll[iwt]*1e9,
+              pythiaPtr[j]->info.sigmaErr()*1e9 );
+            // Write the HepMC event to file.
+            ascii_io_var[iwt]->write_event(hepmcevt);
+          }
+#endif
+        }
+      }
+    }
+  }
+#endif
+
+  // Print cross section, errors.
+  double sumTot(0.), sum2Tot(0.), nacTot(0.);
+  cout << "\nSummary of individual runs:\n";
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    cout << "\nSummary of runs #" << i << " :\n";
+    pythiaPtr[i]->stat();
+    int nAc = pythiaPtr[i]->info.nAccepted();
+    cout << scientific << setprecision(6)
+      << "\n\t Mean shower weight         = " << sumwt[i]/double(nAc) << "\n"
+      << "\t Variance of shower weight  = "
+      << sqrt(1/double(nAc)*(sumwtsq[i] - pow(sumwt[i],2)/double(nAc)))
+      << endl;
+    cout << "\t Inclusive cross section    : " << sigmaInc[i] << "\n";
+    cout << "\t Cross section after shower : " << sigmaTot[i] << "\n";
+    sumTot += sumwt[i];
+    sum2Tot += sumwtsq[i];
+    nacTot += nAc;
+  }
+  cout << "\nCombination of runs:\n"
+    << scientific << setprecision(6)
+    << "\t Mean shower weight         = " << sumTot/nacTot << "\n"
+    << "\t Variance of shower weight  = "
+    << sqrt(1/nacTot*(sum2Tot - pow(sumTot,2)/nacTot ))
+    << " " << 1/nacTot*(sum2Tot - pow(sumTot,2)/nacTot )
+    << "\n"
+    << "\t Cross section after shower : " << sigmaTotAll << "\n";
+
+#ifdef HEPMC3
+  // Clean-up.
+  if ( pythiaPtr.front()->settings.flag("Variations:doVariations") ) {
+    if (printHepMC) for (int iwt=0; iwt < 3; ++iwt) delete ascii_io_var[iwt];
+ }
+#endif
+
+
+  // Write endtag. Overwrite initialization info with new cross sections.
+  ofstream write;
+  write.open("weights.dat");
+  weight_histogram /= double(nacTot);
+  weight_histogram.table(write);
+  write.close();
+  write.open("pos_weights.dat");
+  pos_weight_histogram /= double(nacTot);
+  pos_weight_histogram.table(write);
+  write.close();
+  write.open("neg_weights.dat");
+  neg_weight_histogram /= double(nacTot);
+  neg_weight_histogram.table(write);
+  write.close();
+
+  // Clean-up.
+  for (int i = 0; i < int(pythiaPtr.size()); ++i) {
+    delete pythiaPtr[i]; pythiaPtr[i]=0;
+  }
+
+  // Done.
+  return 0;
+}

--- a/tests/main300.cmnd
+++ b/tests/main300.cmnd
@@ -1,0 +1,34 @@
+! main300.cmnd
+! This file contains commands to be read in for a PYTHIA8/DIRE run.
+! Lines not beginning with a letter or digit are comments.
+! Names are case-insensitive  -  but spellings-sensitive!
+
+! 1) Settings that could be used in a main program, if desired.
+Beams:eCM =  91.188                ! CM energy of collision
+!Beams:eCM =  1000.0                ! CM energy of collision
+Beams:idA =  11                    ! e-
+Beams:idB = -11                    ! e+
+Main:numberOfEvents = 10000       ! number of events to generate
+Next:numberCount = 100             ! print message every n events
+Next:numberShowEvent = 1          ! print event record n times
+Main:timesAllowErrors = 1
+
+! 2) Settings for process generation internal to PYTHIA8.
+WeakSingleBoson:ffbar2gmZ = on     ! process
+! Switch off all Z0 decays and then switch back on the desired channels
+23:onMode = off
+23:onIfAny = 1 2 3 4 5   ! Inclusive hadronic Z decays
+!23:onIfAny = 5           ! Decays to b quarks only, for mass tests
+!23:onIfAny = 11          ! Z decays to electrons, for QED tests
+
+! 3) Optionally switch on/off photon ISR and hadronization
+PDF:lepton = off
+
+! 4) Choose parton shower model.
+! Warning: Dire comes with weighted events.
+PartonShowers:model = 3    ! 1:old showers, 2:vincia, 3:dire
+
+# Use internal Pythia definitions of running coupling and quark masses.
+ShowerPDF:usePDFalphas     = off
+ShowerPDF:useSummedPDF     = on
+ShowerPDF:usePDFmasses     = off

--- a/tests/main42.cc
+++ b/tests/main42.cc
@@ -15,7 +15,7 @@
 // Therefore large event samples may be impractical.
 
 #include "Pythia8/Pythia.h"
-#include "Pythia8Plugins/HepMC3.h"
+#include "Pythia8Plugins/HepMC2.h"
 #include "Pythia8Plugins/ColourReconnectionHooks.h"
 
 using namespace Pythia8;
@@ -44,10 +44,10 @@ int main(int argc, char* argv[]) {
        << argv[2] << " <<< \n" << endl;
 
   // Interface for conversion from Pythia8::Event to HepMC event.
-  HepMC3::Pythia8ToHepMC ToHepMC;
+  HepMC::Pythia8ToHepMC ToHepMC;
 
   // Specify file where HepMC events will be stored.
-  HepMC3::IO_GenEvent ascii_io(argv[2], std::ios::out);
+  HepMC::IO_GenEvent ascii_io(argv[2], std::ios::out);
 
   // Generator.
   Pythia pythia;
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
     // Construct new empty HepMC event and fill it.
     // Units will be as chosen for HepMC build, but can be changed
     // by arguments, e.g. GenEvt( HepMC::Units::GEV, HepMC::Units::MM)
-    HepMC3::GenEvent* hepmcevt = new HepMC3::GenEvent();
+    HepMC::GenEvent* hepmcevt = new HepMC::GenEvent();
     ToHepMC.fill_next_event( pythia, hepmcevt );
 
     // Write the HepMC event to file. Done with it.

--- a/tests/main42.cc
+++ b/tests/main42.cc
@@ -44,10 +44,10 @@ int main(int argc, char* argv[]) {
        << argv[2] << " <<< \n" << endl;
 
   // Interface for conversion from Pythia8::Event to HepMC event.
-  HepMC::Pythia8ToHepMC ToHepMC;
+  HepMC3::Pythia8ToHepMC ToHepMC;
 
   // Specify file where HepMC events will be stored.
-  HepMC::IO_GenEvent ascii_io(argv[2], std::ios::out);
+  HepMC3::IO_GenEvent ascii_io(argv[2], std::ios::out);
 
   // Generator.
   Pythia pythia;
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
     // Construct new empty HepMC event and fill it.
     // Units will be as chosen for HepMC build, but can be changed
     // by arguments, e.g. GenEvt( HepMC::Units::GEV, HepMC::Units::MM)
-    HepMC::GenEvent* hepmcevt = new HepMC::GenEvent();
+    HepMC3::GenEvent* hepmcevt = new HepMC3::GenEvent();
     ToHepMC.fill_next_event( pythia, hepmcevt );
 
     // Write the HepMC event to file. Done with it.

--- a/tests/main42.cc
+++ b/tests/main42.cc
@@ -15,7 +15,7 @@
 // Therefore large event samples may be impractical.
 
 #include "Pythia8/Pythia.h"
-#include "Pythia8Plugins/HepMC2.h"
+#include "Pythia8Plugins/HepMC3.h"
 #include "Pythia8Plugins/ColourReconnectionHooks.h"
 
 using namespace Pythia8;

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,22 @@
+def test_import_hepmc3():
+    import pyHepMC3
+
+    assert pyHepMC3
+
+
+def test_import_lhapdf():
+    import lhapdf
+
+    assert lhapdf
+
+
+def test_import_fastjet():
+    import fastjet
+
+    assert fastjet
+
+
+def test_import_pythia():
+    import pythia8
+
+    assert pythia8


### PR DESCRIPTION
```
* Switch to using HepMC3 from HepMC2.
   - Use HepMC3 v3.2.5.
* Update tests to test PYTHIA8 example main300.
* Add import pytest test tests/test_import.py.
* Update HepMC test in CI.
* Add Python import test in CI.
```