### PR TITLE
ci: Update Docker build to use docker/build-push-action v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,23 +10,40 @@ on:
   schedule:
   - cron:  '1 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - name: Build Docker image
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Test build
+      id: docker_build_test
+      uses: docker/build-push-action@v3
       with:
-        repository: matthewfeickert/pythia-python
-        dockerfile: Dockerfile
-        tags: test
-        tag_with_sha: true
-        tag_with_ref: true
+        context: .
+        file: Dockerfile
+        tags: matthewfeickert/pythia-python:test
+        load: true
         push: false
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build_test.outputs.digest }}
+
+    - name: List built images
+      run: docker images
 
     - name: List Built Images
       run: docker images

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,29 +7,41 @@ on:
     tags:
     - v*
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-publish:
     name: Build and publish Docker images to Docker Hub
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - name: Build and Publish to Registry
-      if: "!(startsWith(github.ref, 'refs/tags/'))"
-      uses: docker/build-push-action@v1
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to DockerHub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: matthewfeickert/pythia-python
-        dockerfile: Dockerfile
-        tags: latest,pythia8.308,pythia8.308-hepmc3.2.5-fastjet3.4.0-python3.10
-    - name: Build and Publish to Registry with Release Tag
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: docker/build-push-action@v1
+
+    - name: Build and publish to registry
+      id: docker_build_latest
+      uses: docker/build-push-action@v3
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: matthewfeickert/pythia-python
-        dockerfile: Dockerfile
-        tags: latest,latest-stable,pythia8.308,pythia8.308-hepmc3.2.5-fastjet3.4.0-python3.10
-        tag_with_ref: true
+        context: .
+        file: Dockerfile
+        tags: ${{ github.repository }}:latest,${{ github.repository }}:pythia8.308,${{ github.repository }}:pythia8.308-hepmc3.2.5-fastjet3.4.0-python3.10
+        labels: |
+          org.opencontainers.image.source=${{ github.event.repository.html_url }}
+          org.opencontainers.image.revision=${{ github.sha }}
+        push: true
+        platforms: linux/amd64


### PR DESCRIPTION
Needed for PR #29.

* docker buildx is needed for more advanced builds which requires modern versions of the docker/build-push-action.